### PR TITLE
Fix startup leader election

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To create a local development environment:
 make dev-denv
 
 # Or if you want to use a custom hostname for Rancher
-RANCHER_HOSTNAME=my.customhost.dev make dev-denv
+RANCHER_HOSTNAME=my.customhost.dev make dev-env
 ```
 
 4. When tilt has started then start ngrok or inlets

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,13 +40,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: 9440
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: 9440
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -15,5 +15,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: manager
   namespace: system

--- a/scripts/kind-cluster-with-extramounts.yaml
+++ b/scripts/kind-cluster-with-extramounts.yaml
@@ -3,6 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: capi-test
 nodes:
 - role: control-plane
+  image: kindest/node:v1.26.3
   extraMounts:
     - hostPath: /var/run/docker.sock
       containerPath: /var/run/docker.sock


### PR DESCRIPTION
kind/bug

**What this PR does / why we need it**:

This PR is a fix for:
- local environment setup, compatible versions between rancher and k8s
- leader election
- health check port
 
Logs are now showing no errors:
```
[event: pod rancher-turtles-system/rancher-turtles-controller-manager-68954b894c-hg4mt] Container image "rancher-sandbox/ghcr.io_rancher-sandbox_rancher-turtles:tilt-06db84abc2b1e90f" already present on machine
I0720 12:55:22.053458       1 request.go:601] Waited for 1.001781355s due to client-side throttling, not priority and fairness, request: GET:[https://10.96.0.1:443/apis/cluster.x-k8s.io/v1alpha3?timeout=32s](https://10.96.0.1/apis/cluster.x-k8s.io/v1alpha3?timeout=32s)
I0720 12:55:22.556030       1 listener.go:44] controller-runtime/metrics "msg"="Metrics server is starting to listen" "addr"=":8080"
I0720 12:55:22.556279       1 main.go:136] setup "msg"="starting manager" "version"="v0.0.0-master+$Format:%H$"
I0720 12:55:22.556352       1 internal.go:366]  "msg"="Starting server" "addr"={"IP":"::","Port":8080,"Zone":""} "kind"="metrics" "path"="/metrics"
I0720 12:55:22.556374       1 internal.go:366]  "msg"="Starting server" "addr"={"IP":"::","Port":9440,"Zone":""} "kind"="health probe"
I0720 12:55:22.556375       1 leaderelection.go:248] attempting to acquire leader lease rancher-turtles-system/controller-leader-election-capi-operator...
I0720 12:55:22.563588       1 leaderelection.go:258] successfully acquired lease rancher-turtles-system/controller-leader-election-capi-operator
I0720 12:55:22.563714       1 controller.go:185]  "msg"="Starting EventSource" "controller"="cluster" "controllerGroup"="cluster.x-k8s.io" "controllerKind"="Cluster" "source"="kind source: *v1beta1.Cluster"
I0720 12:55:22.563731       1 controller.go:185]  "msg"="Starting EventSource" "controller"="cluster" "controllerGroup"="cluster.x-k8s.io" "controllerKind"="Cluster" "source"="kind source: *unstructured.Unstructured"
I0720 12:55:22.563751       1 controller.go:185]  "msg"="Starting EventSource" "controller"="cluster" "controllerGroup"="cluster.x-k8s.io" "controllerKind"="Cluster" "source"="kind source: *v1.Namespace"
I0720 12:55:22.563757       1 controller.go:193]  "msg"="Starting Controller" "controller"="cluster" "controllerGroup"="cluster.x-k8s.io" "controllerKind"="Cluster"
I0720 12:55:22.664218       1 controller.go:227]  "msg"="Starting workers" "controller"="cluster" "controllerGroup"="cluster.x-k8s.io" "controllerKind"="Cluster" "worker count"=1
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
