### PR TITLE
Requeue if rancher cluster name is empty

### DIFF
--- a/internal/controllers/import_controller.go
+++ b/internal/controllers/import_controller.go
@@ -184,6 +184,11 @@ func (r *CAPIImportReconciler) reconcileNormal(ctx context.Context, capiCluster 
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	if rancherCluster.Status.ClusterName == "" {
+		log.Info("cluster name not set yet, requeue")
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	log.Info("found cluster name", "name", rancherCluster.Status.ClusterName)
 
 	if rancherCluster.Status.AgentDeployed {

--- a/internal/controllers/import_controller_test.go
+++ b/internal/controllers/import_controller_test.go
@@ -205,6 +205,22 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 		}
 	})
 
+	It("should reconcile a CAPI cluster when rancher cluster exists but cluster name not set", func() {
+		Expect(cl.Create(ctx, capiCluster)).To(Succeed())
+		capiCluster.Status.ControlPlaneReady = true
+		Expect(cl.Status().Update(ctx, capiCluster)).To(Succeed())
+		Expect(rancherClusterHandler.Create(rancherCluster)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: capiCluster.Namespace,
+				Name:      capiCluster.Name,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.Requeue).To(BeTrue())
+	})
+
 	It("should reconcile a CAPI cluster when rancher cluster exists and agent is deployed", func() {
 		Expect(cl.Create(ctx, capiCluster)).To(Succeed())
 		capiCluster.Status.ControlPlaneReady = true


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Requeue if rancher cluster name is empty, it may not be immediately after creation. 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
