### PR TITLE
✨ Support deleting the cluster from Rancher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# go.work files
+go.work
+go.work.sum
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rancher-sandbox/rancher-turtles
 go 1.20
 
 require (
+	github.com/go-logr/logr v1.2.4
 	github.com/gobuffalo/flect v1.0.2
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
@@ -27,7 +28,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect

--- a/internal/controllers/import_controller_test.go
+++ b/internal/controllers/import_controller_test.go
@@ -116,7 +116,7 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 
 	It("should reconcile a CAPI cluster when rancher cluster doesn't exist", func() {
 		capiCluster.Annotations = map[string]string{
-			importAnnotationName: "true",
+			importAnnotation: "true",
 		}
 		Expect(cl.Create(ctx, capiCluster)).To(Succeed())
 		capiCluster.Status.ControlPlaneReady = true

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNamespace,
 			Annotations: map[string]string{
-				importAnnotationName: "true",
+				importAnnotation: "true",
 			},
 		},
 	})).To(Succeed())

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -1,0 +1,27 @@
+package annotations
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// ClusterImportedAnnotation represents cluster imported annotation.
+	ClusterImportedAnnotation = "imported"
+)
+
+// HasClusterImportAnnotation returns true if the object has the `imported` annotation.
+func HasClusterImportAnnotation(o metav1.Object) bool {
+	return HasAnnotation(o, ClusterImportedAnnotation)
+}
+
+// HasAnnotation returns true if the object has the specified annotation.
+func HasAnnotation(o metav1.Object, annotation string) bool {
+	annotations := o.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	_, ok := annotations[annotation]
+
+	return ok
+}

--- a/util/annotations/helpers_test.go
+++ b/util/annotations/helpers_test.go
@@ -1,0 +1,61 @@
+package annotations
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var _ = Describe("ClusterWithoutImportedAnnotation", func() {
+	BeforeEach(func() {
+		//
+	})
+
+	Context("when object has specifed annotation", func() {
+		It("should return true", func() {
+			obj := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"test-annotation": "value",
+					},
+				},
+			}
+			result := HasAnnotation(obj, "test-annotation")
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	Context("when object does not have specifed annotationn", func() {
+		It("should return false", func() {
+			obj := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-obj",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						"some-other-annotation": "value",
+					},
+				},
+			}
+			result := HasAnnotation(obj, "test-annotation")
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Context("when object has no annotations", func() {
+		It("should return false", func() {
+			obj := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			result := HasAnnotation(obj, "test-annotation")
+			Expect(result).To(BeFalse())
+		})
+	})
+})
+
+func TestAnnotationHelpers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AnnotationHelpers Suite")
+}

--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -1,0 +1,45 @@
+package predicates
+
+import (
+	"strings"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/rancher-sandbox/rancher-turtles/util/annotations"
+)
+
+// ClusterWithoutImportedAnnotation returns a predicate that returns true only if the provided resource does not contain
+// "clusterImportedAnnotation" annotation. When annotation is present on the resource, controller will skip reconciliation.
+func ClusterWithoutImportedAnnotation(logger logr.Logger) predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return processIfClusterNotImported(logger.WithValues("predicate", "ClusterWithoutImportedAnnotation", "eventType", "update"), e.ObjectNew)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return processIfClusterNotImported(logger.WithValues("predicate", "ClusterWithoutImportedAnnotation", "eventType", "create"), e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return processIfClusterNotImported(logger.WithValues("predicate", "ClusterWithoutImportedAnnotation", "eventType", "delete"), e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return processIfClusterNotImported(logger.WithValues("predicate", "ClusterWithoutImportedAnnotation", "eventType", "generic"), e.Object)
+		},
+	}
+}
+
+func processIfClusterNotImported(logger logr.Logger, obj client.Object) bool {
+	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
+	log := logger.WithValues("namespace", obj.GetNamespace(), kind, obj.GetName())
+
+	if annotations.HasAnnotation(obj, annotations.ClusterImportedAnnotation) {
+		log.V(4).Info("Cluster has an import annotation, will not attempt to map resource")
+		return false
+	}
+
+	log.V(6).Info("Cluster does not have an import annotation, will attempt to map resource")
+
+	return true
+}

--- a/util/predicates/cluster_predicates_test.go
+++ b/util/predicates/cluster_predicates_test.go
@@ -1,0 +1,79 @@
+package predicates
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/rancher-turtles/util/annotations"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("ClusterWithoutImportedAnnotation", func() {
+	var logger logr.Logger
+	BeforeEach(func() {
+		// Initialize the logger
+		logger = logr.Discard()
+	})
+
+	Context("when CAPI cluster has clusterImportedAnnotation", func() {
+		It("should return false", func() {
+			capiCluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						annotations.ClusterImportedAnnotation: "true",
+					},
+				},
+			}
+			result := ClusterWithoutImportedAnnotation(logger).UpdateFunc(event.UpdateEvent{ObjectNew: capiCluster})
+			Expect(result).To(BeFalse())
+		})
+	})
+	Context("when CAPI cluster has no annotation", func() {
+		It("should return true", func() {
+			capiCluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"some-other-annoations": "true",
+					},
+				},
+			}
+			capiCluster = &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+			}
+			result := ClusterWithoutImportedAnnotation(logger).UpdateFunc(event.UpdateEvent{ObjectNew: capiCluster})
+			Expect(result).To(BeTrue())
+		})
+	})
+	Context("when CAPI cluster has a random annotation", func() {
+		It("should return true", func() {
+			capiCluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"some-random-annoation": "true"},
+				},
+			}
+			capiCluster = &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-cluster",
+					Namespace:   "test-ns",
+					Annotations: map[string]string{},
+				},
+			}
+			result := ClusterWithoutImportedAnnotation(logger).UpdateFunc(event.UpdateEvent{ObjectNew: capiCluster})
+			Expect(result).To(BeTrue())
+		})
+	})
+})
+
+func TestClusterPredicates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ClusterPredicates Suite")
+}


### PR DESCRIPTION
kind/feature


**What this PR does / why we need it**:
This PR adds a support for deleting the CAPI cluster from Rancher, so that it is no longer listed in Rancher by introducing a 
`clusterImportedAnnotation`.  The cluster creation and deletion then as following:

- renames existing `importAnnotationName` to `importAnnotation` to align with new annotation
- introduces `util` folder where we have `annotations` and `predicates` packages 
- `reconcileDelete` made to receive two inputs: CAPI and Rancher cluster, and  if the Rancher Cluster has `ClusterImportedAnnotation` annotation, then we annotate the CAPI cluster to say don't auto-import again.
- introduces unit tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
