### PR TITLE
Add more linters to .golangci.yml

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.6
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.6
       - name: Lint
         run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,60 @@ linters-settings:
       - "prefix(github.com/rancher-sandbox/rancher-turtles)"
     wsl:
       force-err-cuddling: false
+  importas:
+      no-unaliased: true
+      alias:
+        # Kubernetes
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/util/runtime
+          alias: utilruntime
+        - pkg: k8s.io/client-go/kubernetes/scheme
+          alias: clientgoscheme
+        # Controller Runtime  
+        - pkg: sigs.k8s.io/controller-runtime
+          alias: ctrl
+        # CAPI
+        - pkg: sigs.k8s.io/cluster-api/api/v1beta1
+          alias: clusterv1
+  revive:
+      rules:
+        # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: if-return
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: redefines-builtin-id
+        #
+        # Rules in addition to the recommended configuration above.
+        #
+        - name: bool-literal-in-expr
+        - name: constant-logical-expr
 linters:
   enable-all: true
   disable:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds more linters to .golangci.yml and bumps go to 1.20 in GH workflow files

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
