### PR TITLE
Use label instead of annotation for importing clusters

### DIFF
--- a/internal/controllers/import_controller.go
+++ b/internal/controllers/import_controller.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	importAnnotation             = "rancher-auto-import"
+	importLabelName              = "cluster-api.cattle.io/rancher-auto-import"
 	defaultRequeueDuration       = 1 * time.Minute
 	clusterRegistrationTokenName = "default-token"
 )
@@ -245,13 +245,13 @@ func (r *CAPIImportReconciler) shouldAutoImport(ctx context.Context, capiCluster
 	// Check CAPI cluster for label first
 	hasLabel, autoImport := shouldImport(capiCluster)
 	if hasLabel && autoImport {
-		log.V(2).Info("cluster contains import annotation")
+		log.V(2).Info("Cluster contains import annotation")
 
 		return true, nil
 	}
 
 	if hasLabel && !autoImport {
-		log.V(2).Info("cluster contains annotation to not import")
+		log.V(2).Info("Cluster contains annotation to not import")
 
 		return false, nil
 	}
@@ -323,7 +323,7 @@ func (r *CAPIImportReconciler) getClusterRegistrationManifest(ctx context.Contex
 }
 
 func shouldImport(obj metav1.Object) (hasLabel bool, labelValue bool) {
-	labelVal, ok := obj.GetAnnotations()[importAnnotation]
+	labelVal, ok := obj.GetLabels()[importLabelName]
 	if !ok {
 		return false, false
 	}

--- a/internal/controllers/import_controller_test.go
+++ b/internal/controllers/import_controller_test.go
@@ -115,8 +115,8 @@ var _ = Describe("reconcile CAPI Cluster", func() {
 	})
 
 	It("should reconcile a CAPI cluster when rancher cluster doesn't exist", func() {
-		capiCluster.Annotations = map[string]string{
-			importAnnotation: "true",
+		capiCluster.Labels = map[string]string{
+			importLabelName: "true",
 		}
 		Expect(cl.Create(ctx, capiCluster)).To(Succeed())
 		capiCluster.Status.ControlPlaneReady = true

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -73,8 +73,8 @@ var _ = BeforeSuite(func() {
 	Expect(cl.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNamespace,
-			Annotations: map[string]string{
-				importAnnotation: "true",
+			Labels: map[string]string{
+				importLabelName: "true",
 			},
 		},
 	})).To(Succeed())


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Use label instead of annotation for importing clusters, I also changed label key to `"cluster-api.cattle.io/rancher-auto-import"` so it's more similar to other rancher labels/annotations.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher-sandbox/rancher-turtles/issues/59

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
