### PR TITLE
Revert: downgrade Go to 1.20.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL = /usr/bin/env bash -o pipefail
 #
 # Go.
 #
-GO_VERSION ?= 1.20.7
+GO_VERSION ?= 1.20.4
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 REPO ?= rancher-sandbox/rancher-turtles
 

--- a/tilt/project/Tiltfile
+++ b/tilt/project/Tiltfile
@@ -264,7 +264,7 @@ def get_port_forwards(debug):
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.20.7 as tilt-helper
+FROM golang:1.20.4 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \


### PR DESCRIPTION
**What this PR does / why we need it**:

We bumped Go to 1.20.7 in #66 and this is causing pod `rancher-turtles-controller-manager` to fail when creating a new Tilt development environment. While we troubleshoot and identify the cause of the issue, we agreed to downgrade Go to 1.20.4 in:
- `Makefile`
- `tilt/project/Tiltfile`

This PR is a revert of #66 in these files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
