### PR TITLE
Add CAPI operator as a dependency to chart

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.4.0
+        with:
+          version: v3.9.0
 
       - name: setupGo
         uses: actions/setup-go@v4
@@ -38,6 +40,9 @@ jobs:
 
       - name: Build docker image
         run: make docker-build
+
+      - name: Add CAPI operator chart repo
+        run: helm repo add capi-operator https://kubernetes-sigs.github.io/cluster-api-operator
 
       - name: Package operator chart
         run: make release-chart
@@ -54,7 +59,7 @@ jobs:
         run: kind load docker-image ${{ env.MANIFEST_IMG }}:${{ env.TAG }}
 
       - name: Run chart-testing (install)
-        run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --create-namespace --wait
+        run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --create-namespace --wait --set cluster-api-operator.cert-manager.enabled=true
 
       - name: Run chart-testing (un-install)
         run: helm uninstall rancher-turtles -n rancher-turtles-system --wait

--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,7 @@ build-chart: $(HELM) $(KUSTOMIZE) $(RELEASE_DIR) $(CHART_RELEASE_DIR) $(CHART_PA
 	sed -i'' -e 's@tag: .*@tag: '"$(RELEASE_TAG)"'@' $(CHART_RELEASE_DIR)/values.yaml
 	sed -i'' -e 's@image: .*@image: '"$(CONTROLLER_IMG)"'@' $(CHART_RELEASE_DIR)/values.yaml
 	sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' $(CHART_RELEASE_DIR)/values.yaml
+	$(HELM) dependency update
 	$(HELM) package $(CHART_RELEASE_DIR) --app-version=$(HELM_CHART_TAG) --version=$(HELM_CHART_TAG) --destination=$(CHART_PACKAGE_DIR)
 
 .PHONY: release-chart

--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ build-chart: $(HELM) $(KUSTOMIZE) $(RELEASE_DIR) $(CHART_RELEASE_DIR) $(CHART_PA
 	sed -i'' -e 's@tag: .*@tag: '"$(RELEASE_TAG)"'@' $(CHART_RELEASE_DIR)/values.yaml
 	sed -i'' -e 's@image: .*@image: '"$(CONTROLLER_IMG)"'@' $(CHART_RELEASE_DIR)/values.yaml
 	sed -i'' -e 's@imagePullPolicy: .*@imagePullPolicy: '"$(PULL_POLICY)"'@' $(CHART_RELEASE_DIR)/values.yaml
-	cd $(CHART_RELEASE_DIR) && $(HELM) dependency update 
+	cd $(CHART_RELEASE_DIR) && $(HELM) dependency update
 	$(HELM) package $(CHART_RELEASE_DIR) --app-version=$(HELM_CHART_TAG) --version=$(HELM_CHART_TAG) --destination=$(CHART_PACKAGE_DIR)
 
 .PHONY: release-chart

--- a/charts/rancher-turtles/Chart.lock
+++ b/charts/rancher-turtles/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cluster-api-operator
+  repository: https://kubernetes-sigs.github.io/cluster-api-operator
+  version: 0.5.1
+digest: sha256:14aae11b6d69fba7f570f09c002a66d31c261f53c97d1ee1dd28260c968464ad
+generated: "2023-09-04T18:39:53.870136+02:00"

--- a/charts/rancher-turtles/Chart.yaml
+++ b/charts/rancher-turtles/Chart.yaml
@@ -4,3 +4,8 @@ description: Rancher Turtles
 type: application
 version: 0.0.0
 appVersion: "0.0.0"
+dependencies:
+  - name: cluster-api-operator
+    version: v0.5.1
+    repository: https://kubernetes-sigs.github.io/cluster-api-operator
+    condition: cluster-api-operator.enabled

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -3,3 +3,5 @@ rancherTurtles:
   tag: v0.0.0
   imagePullPolicy: Never
   namespace: rancher-turtles-system
+cluster-api-operator:
+  enabled: true


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Add CAPI operator to helm chart dependency, I will also open a follow-up PR that creates core provider before Rancher turtles are installed.
.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher-sandbox/rancher-turtles/issues/91

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
