### PR TITLE
Remove connectivity check in e2e

### DIFF
--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -28,10 +28,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/rancher-turtles/internal/rancher"
-	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -98,16 +96,6 @@ var _ = Describe("Create and delete CAPI cluster functionality should work", fun
 	})
 
 	It("should successfully create a rancher cluster from a CAPI cluster", func() {
-		By("Waiting for the CAPI cluster to be connectable")
-		Eventually(func() error {
-			remoteClient, err := remote.NewClusterClient(ctx, capiCluster.Name, bootstrapClusterProxy.GetClient(), client.ObjectKeyFromObject(capiCluster))
-			if err != nil {
-				return err
-			}
-			namespaces := &corev1.NamespaceList{}
-			return remoteClient.List(ctx, namespaces)
-		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
-
 		By("Waiting for the rancher cluster record to appear")
 		Eventually(func() error {
 			_, err := rancherClusterHandler.Get(rancherClusterKey)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR removes the cluster connectivity check in e2e. Currently it's not possible to run e2e suite on Mac with Docker desktop because it's impossible to connect to kind cluster using kubeconfig secret, in this case kubeconfig has to be obtained with kind https://cluster-api.sigs.k8s.io/user/quick-start#accessing-the-workload-cluster.

We are testing connectivity anyway later in the test when deploying Rancher agent on the cluster.

cc @furkatgofurov7 @Danil-Grigorev 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
