### PR TITLE
✨ Install CAPI using operator after chart is installed

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -59,7 +59,7 @@ jobs:
         run: kind load docker-image ${{ env.MANIFEST_IMG }}:${{ env.TAG }}
 
       - name: Run chart-testing (install)
-        run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --create-namespace --wait --set cluster-api-operator.cert-manager.enabled=true --set clusterAPI.enabled=false
+        run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --create-namespace --wait --set cluster-api-operator.cluster-api.enabled=false --set cluster-api-operator.enabled=false
 
       - name: Run chart-testing (un-install)
         run: helm uninstall rancher-turtles -n rancher-turtles-system --wait

--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -59,7 +59,7 @@ jobs:
         run: kind load docker-image ${{ env.MANIFEST_IMG }}:${{ env.TAG }}
 
       - name: Run chart-testing (install)
-        run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --create-namespace --wait --set cluster-api-operator.cert-manager.enabled=true
+        run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --create-namespace --wait --set cluster-api-operator.cert-manager.enabled=true --set clusterAPI.enabled=false
 
       - name: Run chart-testing (un-install)
         run: helm uninstall rancher-turtles -n rancher-turtles-system --wait

--- a/README.md
+++ b/README.md
@@ -41,29 +41,31 @@ rancherTurtles:
   tag: v0.0.0 # tag to use for the extension
   imagePullPolicy: Never # image pull policy to use for the extension
   namespace: rancher-turtles-system # namespace to deploy to (default: rancher-turtles-system)
-clusterAPI:
-  enabled: true # indicates if core CAPI controllers should be installed (default: true)
-  version: v1.4.6 # version of CAPI to install (default: v1.4.6)
-  configSecret:
-    name: "" # name of the config secret to use for core CAPI controllers, used by the CAPI operator. See [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#installing-azure-infrastructure-provider) docs for more details.
-    namespace: "" # namespace of the config secret to use for core CAPI controllers, used by the CAPI operator.
-  core:
-    namespace: capi-system
-    fetchConfig: # (only required for airgapped environments)
-      url: ""  # url to fetch config from, used by the CAPI operator. See [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#provider-spec) docs for more details.
-      selector: ""  # selector to use for fetching config, used by the CAPI operator.
-  kubeadmBootstrap:
-    namespace: capi-kubeadm-bootstrap-system
-    fetchConfig:
-      url: ""
-      selector: ""
-  kubeadmControlPlane:
-    namespace: capi-kubeadm-control-plane-system
-    fetchConfig:
-      url: ""
-      selector: ""
 cluster-api-operator: 
   enabled: true # indicates if CAPI operator should be installed (default: true)
+  cert-manager:
+    enabled: true # indicates if cert-manager should be installed (default: true)
+  cluster-api:
+    enabled: true # indicates if core CAPI controllers should be installed (default: true)
+    version: v1.4.6 # version of CAPI to install (default: v1.4.6)
+    configSecret:
+      name: "" # name of the config secret to use for core CAPI controllers, used by the CAPI operator. See [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#installing-azure-infrastructure-provider) docs for more details.
+      namespace: "" # namespace of the config secret to use for core CAPI controllers, used by the CAPI operator.
+    core:
+      namespace: capi-system
+      fetchConfig: # (only required for airgapped environments)
+        url: ""  # url to fetch config from, used by the CAPI operator. See [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#provider-spec) docs for more details.
+        selector: ""  # selector to use for fetching config, used by the CAPI operator.
+    kubeadmBootstrap:
+      namespace: capi-kubeadm-bootstrap-system
+      fetchConfig:
+        url: ""
+        selector: ""
+    kubeadmControlPlane:
+      namespace: capi-kubeadm-control-plane-system
+      fetchConfig:
+        url: ""
+        selector: ""
 
 ```
 ### Installing CAPI providers

--- a/README.md
+++ b/README.md
@@ -10,7 +10,72 @@ Currently this project has the following functionality:
 
 ## How to use this?
 
-Instructions coming soon :)
+### Installation
+
+```
+Note: The following will only work after we release the first version of the extension.
+```
+
+Prerequisites:
+
+- Running [Rancher Manager cluster](https://ranchermanager.docs.rancher.com/) with cert-manager
+- [Helm](https://helm.sh/)
+
+Quick start:
+
+These commands will install: Rancher turtles extension, CAPI Operator, CAPI itself with kubeadmin bootstrap and control plane providers.
+
+```bash
+helm repo add rancher-turtles https://rancher-sandbox.github.io/rancher-turtles
+helm repo update
+helm install rancher-turtles rancher-turtles/rancher-turtles --create-namespace -n rancher-turtles-system
+```
+
+Customizing the deployment:
+
+The Rancher turtles Helm chart supports the following values:
+
+```yaml
+rancherTurtles:
+  image: controller # image to use for the extension
+  tag: v0.0.0 # tag to use for the extension
+  imagePullPolicy: Never # image pull policy to use for the extension
+  namespace: rancher-turtles-system # namespace to deploy to (default: rancher-turtles-system)
+clusterAPI:
+  enabled: true # indicates if core CAPI controllers should be installed (default: true)
+  version: v1.4.6 # version of CAPI to install (default: v1.4.6)
+  configSecret:
+    name: "" # name of the config secret to use for core CAPI controllers, used by the CAPI operator. See [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#installing-azure-infrastructure-provider) docs for more details.
+    namespace: "" # namespace of the config secret to use for core CAPI controllers, used by the CAPI operator.
+  core:
+    namespace: capi-system
+    fetchConfig: # (only required for airgapped environments)
+      url: ""  # url to fetch config from, used by the CAPI operator. See [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#provider-spec) docs for more details.
+      selector: ""  # selector to use for fetching config, used by the CAPI operator.
+  kubeadmBootstrap:
+    namespace: capi-kubeadm-bootstrap-system
+    fetchConfig:
+      url: ""
+      selector: ""
+  kubeadmControlPlane:
+    namespace: capi-kubeadm-control-plane-system
+    fetchConfig:
+      url: ""
+      selector: ""
+cluster-api-operator: 
+  enabled: true # indicates if CAPI operator should be installed (default: true)
+
+```
+### Installing CAPI providers
+
+The Rancher turtles extension does not install any CAPI providers, you will need to install them yourself using [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs).
+ 
+To quickly deploy docker infrastructure, kubeadm bootstrap and control plane providers, apply the following:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles/main/test/e2e/resources/config/capi-providers-secret.yaml
+kubectl apply -f https://raw.githubusercontent.com/rancher-sandbox/rancher-turtles/main/test/e2e/resources/config/capi-providers.yaml
+```
 
 ## How to contribute?
 See our [contributor guide](CONTRIBUTING.md) for more details on how to get involved.

--- a/charts/rancher-turtles/Chart.yaml
+++ b/charts/rancher-turtles/Chart.yaml
@@ -8,4 +8,4 @@ dependencies:
   - name: cluster-api-operator
     version: v0.5.1
     repository: https://kubernetes-sigs.github.io/cluster-api-operator
-    condition: clusterAPIOperator.enabled
+    condition: cluster-api-operator.enabled

--- a/charts/rancher-turtles/Chart.yaml
+++ b/charts/rancher-turtles/Chart.yaml
@@ -8,4 +8,4 @@ dependencies:
   - name: cluster-api-operator
     version: v0.5.1
     repository: https://kubernetes-sigs.github.io/cluster-api-operator
-    condition: cluster-api-operator.enabled
+    condition: clusterAPIOperator.enabled

--- a/charts/rancher-turtles/templates/core-provider.yaml
+++ b/charts/rancher-turtles/templates/core-provider.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterAPI.enabled }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "enabled" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -6,34 +6,34 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "1"
-  name: {{ .Values.clusterAPI.core.namespace }}
+  name: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
 ---
 apiVersion: operator.cluster.x-k8s.io/v1alpha1
 kind: CoreProvider
 metadata:
   name: cluster-api
-  namespace: {{ .Values.clusterAPI.core.namespace }}
+  namespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"
 spec:
-  version: {{ $.Values.clusterAPI.version }}
+  version: {{ index .Values "cluster-api-operator" "cluster-api" "version" }}
   additionalManifests:
     name: capi-additional-rbac-roles
-    namespace: {{ .Values.clusterAPI.core.namespace }}
-{{- if $.Values.clusterAPI.configSecret.name }}
-  secretName: {{ $.Values.clusterAPI.configSecret.name }}
-{{- if $.Values.clusterAPI.configSecret.namespace }}
-  secretNamespace: {{ $.Values.clusterAPI.configSecret.namespace }}
+    namespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
+  secretName: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
+  secretNamespace: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
 {{- end }}
 {{- end }}
-{{- if or $.Values.clusterAPI.core.fetchConfig.url $.Values.clusterAPI.core.fetchConfig.selector }}
+{{- if or (index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "url") (index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "selector") }}
   fetchConfig:
-    {{- if $.Values.clusterAPI.core.fetchConfig.url }}
-    url: {{ $.Values.clusterAPI.core.fetchConfig.url }}
+    {{- if index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "url" }}
+    url: {{ index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "url" }}
     {{- end }}
-    {{- if $.Values.clusterAPI.core.fetchConfig.selector }}
-    selector: {{ $.Values.clusterAPI.core.fetchConfig.selector }}
+    {{- if index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "selector" }}
+    selector: {{ index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "selector" }}
     {{- end }}
 {{- end }}
 ---
@@ -41,7 +41,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: capi-additional-rbac-roles
-  namespace: {{ .Values.clusterAPI.core.namespace }}
+  namespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"

--- a/charts/rancher-turtles/templates/core-provider.yaml
+++ b/charts/rancher-turtles/templates/core-provider.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.clusterAPI.enabled }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-weight": "1"
+  name: {{ .Values.clusterAPI.core.namespace }}
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha1
+kind: CoreProvider
+metadata:
+  name: cluster-api
+  namespace: {{ .Values.clusterAPI.core.namespace }}
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-weight": "2"
+spec:
+  version: {{ $.Values.clusterAPI.version }}
+  additionalManifests:
+    name: capi-additional-rbac-roles
+    namespace: {{ .Values.clusterAPI.core.namespace }}
+{{- if $.Values.clusterAPI.configSecret.name }}
+  secretName: {{ $.Values.clusterAPI.configSecret.name }}
+{{- if $.Values.clusterAPI.configSecret.namespace }}
+  secretNamespace: {{ $.Values.clusterAPI.configSecret.namespace }}
+{{- end }}
+{{- end }}
+{{- if or $.Values.clusterAPI.core.fetchConfig.url $.Values.clusterAPI.core.fetchConfig.selector }}
+  fetchConfig:
+    {{- if $.Values.clusterAPI.core.fetchConfig.url }}
+    url: {{ $.Values.clusterAPI.core.fetchConfig.url }}
+    {{- end }}
+    {{- if $.Values.clusterAPI.core.fetchConfig.selector }}
+    selector: {{ $.Values.clusterAPI.core.fetchConfig.selector }}
+    {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: capi-additional-rbac-roles
+  namespace: {{ .Values.clusterAPI.core.namespace }}
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-weight": "2"
+data: 
+  manifests: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: provisioning-rke-cattle-io
+      labels:
+        cluster.x-k8s.io/aggregate-to-manager: "true"
+    rules:
+      - apiGroups: ["rke.cattle.io"]
+        resources: ["*"]
+        verbs: ["*"]
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: provisioning-rke-machine-cattle-io
+      labels:
+        cluster.x-k8s.io/aggregate-to-manager: "true"
+    rules:
+      - apiGroups: ["rke-machine.cattle.io"]
+        resources: ["*"]
+        verbs: ["*"]
+{{- end }}

--- a/charts/rancher-turtles/templates/kubeadm-bootstrap.yaml
+++ b/charts/rancher-turtles/templates/kubeadm-bootstrap.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.clusterAPI.enabled }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-weight": "1"
+  name: {{ .Values.clusterAPI.kubeadmBootstrap.namespace }}
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha1
+kind: BootstrapProvider
+metadata:
+  name: kubeadm
+  namespace: {{ .Values.clusterAPI.kubeadmBootstrap.namespace }}
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-weight": "2"
+spec:
+  version: {{ $.Values.clusterAPI.version }}
+{{- if $.Values.clusterAPI.configSecret.name }}
+  secretName: {{ $.Values.clusterAPI.configSecret.name }}
+{{- if $.Values.clusterAPI.configSecret.namespace }}
+  secretNamespace: {{ $.Values.clusterAPI.configSecret.namespace }}
+{{- end }}
+{{- end }}
+{{- if or $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.url $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.selector }}
+  fetchConfig:
+    {{- if $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.url }}
+    url: {{ $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.url }}
+    {{- end }}
+    {{- if $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.selector }}
+    selector: {{ $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.selector }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles/templates/kubeadm-bootstrap.yaml
+++ b/charts/rancher-turtles/templates/kubeadm-bootstrap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterAPI.enabled }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "enabled" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -6,31 +6,31 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "1"
-  name: {{ .Values.clusterAPI.kubeadmBootstrap.namespace }}
+  name: {{ index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "namespace" }}
 ---
 apiVersion: operator.cluster.x-k8s.io/v1alpha1
 kind: BootstrapProvider
 metadata:
   name: kubeadm
-  namespace: {{ .Values.clusterAPI.kubeadmBootstrap.namespace }}
+  namespace: {{ index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "namespace" }}
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"
 spec:
-  version: {{ $.Values.clusterAPI.version }}
-{{- if $.Values.clusterAPI.configSecret.name }}
-  secretName: {{ $.Values.clusterAPI.configSecret.name }}
-{{- if $.Values.clusterAPI.configSecret.namespace }}
-  secretNamespace: {{ $.Values.clusterAPI.configSecret.namespace }}
+  version: {{ index .Values "cluster-api-operator" "cluster-api" "version" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
+  secretName: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
+  secretNamespace: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
 {{- end }}
 {{- end }}
-{{- if or $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.url $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.selector }}
+{{- if or (index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "fetchConfig" "url") (index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "fetchConfig" "selector") }}
   fetchConfig:
-    {{- if $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.url }}
-    url: {{ $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.url }}
+    {{- if index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "fetchConfig" "url" }}
+    url: {{ index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "fetchConfig" "url" }}
     {{- end }}
-    {{- if $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.selector }}
-    selector: {{ $.Values.clusterAPI.kubeadmBootstrap.fetchConfig.selector }}
+    {{- if index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "fetchConfig" "selector" }}
+    selector: {{ index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "fetchConfig" "selector" }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rancher-turtles/templates/kubeadm-control-plane.yaml
+++ b/charts/rancher-turtles/templates/kubeadm-control-plane.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.clusterAPI.enabled }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-weight": "1"
+  name: {{ .Values.clusterAPI.kubeadmControlPlane.namespace }}
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha1
+kind: ControlPlaneProvider
+metadata:
+  name: kubeadm
+  namespace: {{ .Values.clusterAPI.kubeadmControlPlane.namespace }}
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-weight": "2"
+spec:
+  version: {{ $.Values.clusterAPI.version }}
+{{- if $.Values.clusterAPI.configSecret.name }}
+  secretName: {{ $.Values.clusterAPI.configSecret.name }}
+{{- if $.Values.clusterAPI.configSecret.namespace }}
+  secretNamespace: {{ $.Values.clusterAPI.configSecret.namespace }}
+{{- end }}
+{{- end }}
+{{- if or $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.url $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.selector }}
+  fetchConfig:
+    {{- if $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.url }}
+    url: {{ $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.url }}
+    {{- end }}
+    {{- if $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.selector }}
+    selector: {{ $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.selector }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rancher-turtles/templates/kubeadm-control-plane.yaml
+++ b/charts/rancher-turtles/templates/kubeadm-control-plane.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterAPI.enabled }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "enabled" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -6,31 +6,31 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "1"
-  name: {{ .Values.clusterAPI.kubeadmControlPlane.namespace }}
+  name: {{ index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "namespace" }}
 ---
 apiVersion: operator.cluster.x-k8s.io/v1alpha1
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
-  namespace: {{ .Values.clusterAPI.kubeadmControlPlane.namespace }}
+  namespace: {{ index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "namespace" }}
   annotations:
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-weight": "2"
 spec:
-  version: {{ $.Values.clusterAPI.version }}
-{{- if $.Values.clusterAPI.configSecret.name }}
-  secretName: {{ $.Values.clusterAPI.configSecret.name }}
-{{- if $.Values.clusterAPI.configSecret.namespace }}
-  secretNamespace: {{ $.Values.clusterAPI.configSecret.namespace }}
+  version: {{ index .Values "cluster-api-operator" "cluster-api" "version" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
+  secretName: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
+{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
+  secretNamespace: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
 {{- end }}
 {{- end }}
-{{- if or $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.url $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.selector }}
+{{- if or (index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "fetchConfig" "url") (index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "fetchConfig" "selector") }}
   fetchConfig:
-    {{- if $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.url }}
-    url: {{ $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.url }}
+    {{- if index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "fetchConfig" "url" }}
+    url: {{ index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "fetchConfig" "url" }}
     {{- end }}
-    {{- if $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.selector }}
-    selector: {{ $.Values.clusterAPI.kubeadmControlPlane.fetchConfig.selector }}
+    {{- if index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "fetchConfig" "selector" }}
+    selector: {{ index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "fetchConfig" "selector" }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -3,26 +3,28 @@ rancherTurtles:
   tag: v0.0.0
   imagePullPolicy: Never
   namespace: rancher-turtles-system
-clusterAPI:
-  enabled: true
-  version: v1.4.6
-  configSecret:
-    name: ""
-    namespace: ""
-  core:
-    namespace: capi-system
-    fetchConfig:
-      url: ""
-      selector: ""
-  kubeadmBootstrap:
-    namespace: capi-kubeadm-bootstrap-system
-    fetchConfig:
-      url: ""
-      selector: ""
-  kubeadmControlPlane:
-    namespace: capi-kubeadm-control-plane-system
-    fetchConfig:
-      url: ""
-      selector: ""
 cluster-api-operator:
   enabled: true
+  cert-manager:
+    enabled: true
+  cluster-api:
+    enabled: true
+    version: v1.4.6
+    configSecret:
+      name: ""
+      namespace: ""
+    core:
+      namespace: capi-system
+      fetchConfig:
+        url: ""
+        selector: ""
+    kubeadmBootstrap:
+      namespace: capi-kubeadm-bootstrap-system
+      fetchConfig:
+        url: ""
+        selector: ""
+    kubeadmControlPlane:
+      namespace: capi-kubeadm-control-plane-system
+      fetchConfig:
+        url: ""
+        selector: ""

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -3,5 +3,26 @@ rancherTurtles:
   tag: v0.0.0
   imagePullPolicy: Never
   namespace: rancher-turtles-system
+clusterAPI:
+  enabled: true
+  version: v1.4.6
+  configSecret:
+    name: ""
+    namespace: ""
+  core:
+    namespace: capi-system
+    fetchConfig:
+      url: ""
+      selector: ""
+  kubeadmBootstrap:
+    namespace: capi-kubeadm-bootstrap-system
+    fetchConfig:
+      url: ""
+      selector: ""
+  kubeadmControlPlane:
+    namespace: capi-kubeadm-control-plane-system
+    fetchConfig:
+      url: ""
+      selector: ""
 cluster-api-operator:
   enabled: true

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -258,9 +258,8 @@ func initRancherTurtles(clusterProxy framework.ClusterProxy, config *clusterctl.
 		AdditionalFlags: Flags("-n", rancherTurtlesNamespace, "--create-namespace", "--wait"),
 	}
 	_, err := chart.Run(map[string]string{
-		"cluster-api-operator.cert-manager.enabled": "true",
-		"clusterAPI.configSecret.namespace":         "default",
-		"clusterAPI.configSecret.name":              "variables",
+		"cluster-api-operator.cluster-api.configSecret.namespace": "default",
+		"cluster-api-operator.cluster-api.configSecret.name":      "variables",
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -30,8 +30,11 @@ var (
 	//go:embed resources/testdata/fleet-capi-test.yaml
 	fleetCAPITestdata []byte
 
-	//go:embed resources/config/docker-infra-secret.yaml
-	dockerVariablesSecret []byte
+	//go:embed resources/config/capi-providers-secret.yaml
+	capiProvidersSecret []byte
+
+	//go:embed resources/config/capi-providers.yaml
+	capiProviders []byte
 
 	//go:embed resources/config/ingress.yaml
 	ingressConfig []byte

--- a/test/e2e/resources/config/capi-providers-secret.yaml
+++ b/test/e2e/resources/config/capi-providers-secret.yaml
@@ -7,3 +7,4 @@ type: Opaque
 stringData:
   CLUSTER_TOPOLOGY: "true"
   EXP_CLUSTER_RESOURCE_SET: "true"
+

--- a/test/e2e/resources/config/capi-providers.yaml
+++ b/test/e2e/resources/config/capi-providers.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capd-system
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha1
+kind: InfrastructureProvider
+metadata:
+  name: docker
+  namespace: capd-system
+spec:
+  secretName: variables
+  secretNamespace: default


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->
kind/feature

**What this PR does / why we need it**:

Add new values and template to helm chart so we can deploy CAPI with one command, assuming rancher and cert-manager are running users will be able to install extension, CAPI operator and CAPI like this:
```
helm repo add rancher-turtles https://rancher-sandbox.github.io/rancher-turtles
helm repo update
helm install rancher-turtles rancher-turtles/rancher-turtles --create-namespace -n rancher-turtles-system
```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher-sandbox/rancher-turtles/issues/18
Fixes https://github.com/rancher-sandbox/rancher-turtles/issues/105

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
