### PR TITLE
🐛 Fix cluster connectivity check on mac

### DIFF
--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/rancher-turtles/internal/rancher"
-	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
@@ -100,11 +99,8 @@ var _ = Describe("Create and delete CAPI cluster functionality should work", fun
 	It("should successfully create a rancher cluster from a CAPI cluster", func() {
 		By("Waiting for the CAPI cluster to be connectable")
 		Eventually(func() error {
-			remoteClient, err := remote.NewClusterClient(ctx, capiCluster.Name, bootstrapClusterProxy.GetClient(), client.ObjectKeyFromObject(capiCluster))
-			if err != nil {
-				return err
-			}
 			namespaces := &corev1.NamespaceList{}
+			remoteClient := bootstrapClusterProxy.GetWorkloadCluster(ctx, capiCluster.Name, capiCluster.Namespace).GetClient()
 			return remoteClient.List(ctx, namespaces)
 		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-rancher")...).Should(Succeed())
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Using cluster proxy directly will eliminate the issue with cluster connectivity check on mac, as it uses fix for load balancer address described in https://cluster-api.sigs.k8s.io/clusterctl/developers#fix-kubeconfig-when-using-docker-desktop-and-clusterctl

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
