### PR TITLE
chore: disable link checker for the template

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -12,10 +12,12 @@
 # Title
 <!-- A short and clear title which is prefixed with the ADR number -->
 
-* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- mandatory -->
-* Date: 2020-10-29 [YYY-MM-DD - date of the decision] <!-- mandatory -->
-* Authors: [list of GitHub handles for the authors]
-* Deciders: [list of GitHub handles for those that made the decision]  <!-- mandatory -->
+<!-- TODO: remove the following disable link checker comment before committing your ADR -->
+<!-- markdown-link-check-disable-next-line -->
+- Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- mandatory -->
+- Date: 2020-10-29 [YYY-MM-DD - date of the decision] <!-- mandatory -->
+- Authors: [list of GitHub handles for the authors]
+- Deciders: [list of GitHub handles for those that made the decision]  <!-- mandatory -->
 
 ## Context
 <!-- What is the context of the decision and what's the motivation -->


### PR DESCRIPTION
**What this PR does / why we need it**:

This change disable the link checker for the ADR template file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

