### PR TITLE
🌱 Use upstream repo instead of forked in e2e testing

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -53,6 +53,6 @@ const (
 	operatorNamespace       = "capi-operator-system"
 	rancherTurtlesNamespace = "rancher-turtles-system"
 	rancherNamespace        = "cattle-system"
-	capiClusterName         = "test2"
-	capiClusterNamespace    = "fleet-default"
+	capiClusterName         = "cluster1"
+	capiClusterNamespace    = "default"
 )

--- a/test/e2e/resources/testdata/fleet-capi-test.yaml
+++ b/test/e2e/resources/testdata/fleet-capi-test.yaml
@@ -9,3 +9,11 @@ spec:
   forceSyncGeneration: ${fleetGeneration}
   paths:
   - clusters
+---
+# Temporarily update namespace labels manually to ensure the cluster is imported
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    cluster-api.cattle.io/rancher-auto-import: "true"

--- a/test/e2e/resources/testdata/fleet-capi-test.yaml
+++ b/test/e2e/resources/testdata/fleet-capi-test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: manifests
   namespace: fleet-local
 spec:
-  repo: https://github.com/Danil-Grigorev/fleet-clusters
+  repo: https://github.com/rancher-sandbox/rancher-turtles-fleet-example
   branch: main
   forceSyncGeneration: ${fleetGeneration}
   paths:


### PR DESCRIPTION
**What this PR does / why we need it**:
Point to upstream repo instead of forked one in e2e testing

**Special notes for your reviewer**:
@Danil-Grigorev I found this commit https://github.com/richardcase/fleet-clusters/compare/main...Danil-Grigorev:fleet-clusters:main on top of the https://github.com/rancher-sandbox/rancher-turtles-fleet-example repo commits. Does the latter need to be synced with your fork or can be dropped?

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
