### PR TITLE
✨ Add nightly chart and image publish GH workflow

### DIFF
--- a/.github/workflows/nightly-chart-and-image-publish.yaml
+++ b/.github/workflows/nightly-chart-and-image-publish.yaml
@@ -1,0 +1,70 @@
+name: Build and Publish nightly Helm chart and Docker images
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at midnight (UTC)
+
+env:
+  TAG: ${{ github.ref_name }}
+  REGISTRY: ghcr.io
+  PROD_REGISTRY: ghcr.io
+
+permissions: {
+  packages: read|write
+}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: setupGo
+      uses: actions/setup-go@v4
+      with:
+        go-version: '=1.20.7'
+    - name: Docker login
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build docker image
+      run: make docker-build-all TAG=${{ env.TAG }}
+    - name: Push docker image
+      run: make docker-push-all TAG=${{ env.TAG }} PROD_REGISTRY=${{ env.REGISTRY }}
+
+  release-helm:
+    name: Release Helm chart
+    env:
+      HELM_EXPERIMENTAL_OCI: 1
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'rancher-turtles'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Install Helm
+        uses: Azure/setup-helm@v3
+        with:
+          version: 3.8.0
+
+      - name: Build Helm chart
+        run: make release-chart
+
+      - name: Login to ghcr.io using Helm
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.repository_owner }} --password-stdin
+
+      - name: Publish Helm chart to GHCR
+        env:
+          GHCR_REPOSITORY: ${{ github.repository_owner }}/rancher-turtles-chart
+        run: |
+          helm push out/package/rancher-turtles-0.0.0.tgz oci://ghcr.io/${GHCR_REPOSITORY}/rancher-turtles-chart

--- a/.github/workflows/nightly-chart-and-image-publish.yaml
+++ b/.github/workflows/nightly-chart-and-image-publish.yaml
@@ -3,15 +3,11 @@ name: Build and Publish nightly Helm chart and Docker images
 on:
   schedule:
     - cron: "0 0 * * *" # Run every day at midnight (UTC)
+  workflow_dispatch: # Allow running manually on demand
 
 env:
-  TAG: ${{ github.ref_name }}
+  TAG: ${{ github.sha }}
   REGISTRY: ghcr.io
-  PROD_REGISTRY: ghcr.io
-
-permissions: {
-  packages: read|write
-}
 
 jobs:
   build:
@@ -37,14 +33,18 @@ jobs:
     - name: Build docker image
       run: make docker-build-all TAG=${{ env.TAG }}
     - name: Push docker image
-      run: make docker-push-all TAG=${{ env.TAG }} PROD_REGISTRY=${{ env.REGISTRY }}
+      run: make docker-push-all TAG=${{ env.TAG }}
 
   release-helm:
     name: Release Helm chart
+    needs: 
+    - build
+    permissions:
+      contents: read
+      packages: write
     env:
       HELM_EXPERIMENTAL_OCI: 1
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'rancher-turtles'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
           version: 3.8.0
 
       - name: Build Helm chart
-        run: make release-chart
+        run: make release-chart RELEASE_TAG=v0.0.0-${{ github.sha }}
 
       - name: Login to ghcr.io using Helm
         run: |
@@ -67,4 +67,4 @@ jobs:
         env:
           GHCR_REPOSITORY: ${{ github.repository_owner }}/rancher-turtles-chart
         run: |
-          helm push out/package/rancher-turtles-0.0.0.tgz oci://ghcr.io/${GHCR_REPOSITORY}/rancher-turtles-chart
+          helm push out/package/rancher-turtles-0.0.0-${{ github.sha }}.tgz oci://ghcr.io/${{ github.repository_owner }}/rancher-turtles-chart


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds nightly rancher turtles chart and docker image publishing GitHub workflow which runs every day to ghcr.io 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of: https://github.com/rancher-sandbox/rancher-turtles/issues/117

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
