### PR TITLE
feat: update chart to enable crs and topology features

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ cluster-api-operator:
   cluster-api:
     enabled: true # indicates if core CAPI controllers should be installed (default: true)
     version: v1.4.6 # version of CAPI to install (default: v1.4.6)
-    configSecret:
+    configSecret: # set the name/namespace of configuration secret. Leave empty unless you want to use your own secret.
       name: "" # name of the config secret to use for core CAPI controllers, used by the CAPI operator. See [CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/tree/main/docs#installing-azure-infrastructure-provider) docs for more details.
       namespace: "" # namespace of the config secret to use for core CAPI controllers, used by the CAPI operator.
+      defaultName: "capi-env-variables" # default name for the secret.
     core:
       namespace: capi-system
       fetchConfig: # (only required for airgapped environments)

--- a/charts/rancher-turtles/templates/core-provider.yaml
+++ b/charts/rancher-turtles/templates/core-provider.yaml
@@ -21,11 +21,12 @@ spec:
   additionalManifests:
     name: capi-additional-rbac-roles
     namespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
+{{- if and (index .Values "cluster-api-operator" "cluster-api" "configSecret" "name") (index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace") }}
   secretName: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
   secretNamespace: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
-{{- end }}
+{{ else }}
+  secretName: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "defaultName" }}
+  secretNamespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
 {{- end }}
 {{- if or (index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "url") (index .Values "cluster-api-operator" "cluster-api" "core" "fetchConfig" "selector") }}
   fetchConfig:
@@ -68,4 +69,19 @@ data:
       - apiGroups: ["rke-machine.cattle.io"]
         resources: ["*"]
         verbs: ["*"]
+---
+{{- if not (and (index .Values "cluster-api-operator" "cluster-api" "configSecret" "name") (index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace")) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "defaultName" }}
+  namespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-weight": "2"
+type: Opaque
+stringData:
+  CLUSTER_TOPOLOGY: "true"
+  EXP_CLUSTER_RESOURCE_SET: "true"
+{{- end }}
 {{- end }}

--- a/charts/rancher-turtles/templates/kubeadm-bootstrap.yaml
+++ b/charts/rancher-turtles/templates/kubeadm-bootstrap.yaml
@@ -18,11 +18,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: {{ index .Values "cluster-api-operator" "cluster-api" "version" }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
+{{- if and (index .Values "cluster-api-operator" "cluster-api" "configSecret" "name") (index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace") }}
   secretName: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
   secretNamespace: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
-{{- end }}
+{{ else }}
+  secretName: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "defaultName" }}
+  secretNamespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
 {{- end }}
 {{- if or (index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "fetchConfig" "url") (index .Values "cluster-api-operator" "cluster-api" "kubeadmBootstrap" "fetchConfig" "selector") }}
   fetchConfig:

--- a/charts/rancher-turtles/templates/kubeadm-control-plane.yaml
+++ b/charts/rancher-turtles/templates/kubeadm-control-plane.yaml
@@ -18,11 +18,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: {{ index .Values "cluster-api-operator" "cluster-api" "version" }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
+{{- if and (index .Values "cluster-api-operator" "cluster-api" "configSecret" "name") (index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace") }}
   secretName: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "name" }}
-{{- if index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
   secretNamespace: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "namespace" }}
-{{- end }}
+{{ else }}
+  secretName: {{ index .Values "cluster-api-operator" "cluster-api" "configSecret" "defaultName" }}
+  secretNamespace: {{ index .Values "cluster-api-operator" "cluster-api" "core" "namespace" }}
 {{- end }}
 {{- if or (index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "fetchConfig" "url") (index .Values "cluster-api-operator" "cluster-api" "kubeadmControlPlane" "fetchConfig" "selector") }}
   fetchConfig:

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -14,6 +14,7 @@ cluster-api-operator:
     configSecret:
       name: ""
       namespace: ""
+      defaultName: capi-env-variables
     core:
       namespace: capi-system
       fetchConfig:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the chart so that  when it deploys the CoreProvider it also sets the environment variables for the features:

- CRS
- Topology

These features are currently set by [manually creating a secret](https://docs.rancher-turtles.com/docs/getting-started/install_turtles_operator) with the desired values for the environment variables `CLUSTER_TOPOLOGY` and `EXP_CLUSTER_RESOURCE_SET`. This secret will now be created as part of the chart installation and both features will default to `true`. These can otherwise be disabled passing the parameters to Helm:

`--set cluster-api-operator.cluster-api.secretConfig.name="user-secret-name"`
`--set cluster-api-operator.cluster-api.secretConfig.namespace="user-secret-namespace`

When both these parameters are provided, the secret is expected to exist in the namespace and the user must manage its contents, including (but not limited to) `CLUSTER_TOPOLOGY` and `EXP_CLUSTER_RESOURCE_SET`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #130 

**Special notes for your reviewer**:

README is updated with the new values and a new issue is created to track `rancher-turtles-docs` updates rancher-sandbox/rancher-turtles-docs#27.

**Checklist**:

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
