### PR TITLE
feat: add CAPA e2e test

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -12,6 +12,7 @@ env:
   NGROK_API_KEY: ${{ secrets.NGROK_API_KEY }}
   RANCHER_HOSTNAME: ${{ secrets.NGROK_DOMAIN }}
   RANCHER_PASSWORD: ${{ secrets.RANCHER_PASSWORD }}
+  CAPA_ENCODED_CREDS: ${{ secrets.CAPA_ENCODED_CREDS }}
 
 jobs:
   e2e:

--- a/.github/workflows/e2e-short.yaml
+++ b/.github/workflows/e2e-short.yaml
@@ -16,7 +16,7 @@ jobs:
       with:
         go-version: '=1.20.7'
     - name: Run e2e tests
-      run: ISOLATED_MODE=true make test-e2e
+      run: ISOLATED_MODE=true GINKGO_LABEL_FILTER=short make test-e2e
     - name: Collect run artifacts
       if: always()
       uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ SKIP_RESOURCE_CLEANUP ?= false
 USE_EXISTING_CLUSTER ?= false
 ISOLATED_MODE ?= false
 GINKGO_NOCOLOR ?= false
+GINKGO_LABEL_FILTER ?= "short || full"
 
 # to set multiple ginkgo skip flags, if any
 ifneq ($(strip $(GINKGO_SKIP)),)
@@ -465,7 +466,7 @@ release-chart: $(HELM) $(NOTES) build-chart verify-gen
 test-e2e: $(GINKGO) $(HELM) $(CLUSTERCTL) kubectl e2e-image ## Run the end-to-end tests
 	RANCHER_HOSTNAME=$(RANCHER_HOSTNAME) \
 	$(GINKGO) -v --trace -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) \
-		-poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) --tags=e2e --focus="$(GINKGO_FOCUS)" \
+		-poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) --tags=e2e --focus="$(GINKGO_FOCUS)" --label-filter="$(GINKGO_LABEL_FILTER)" \
 		$(_SKIP_ARGS) --nodes=$(GINKGO_NODES) --timeout=$(GINKGO_TIMEOUT) --no-color=$(GINKGO_NOCOLOR) \
 		--output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" $(GINKGO_ARGS) $(ROOT_DIR)/$(TEST_DIR)/e2e -- \
 	    -e2e.artifacts-folder="$(ARTIFACTS)" \

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -8,9 +8,11 @@ images:
 intervals:
   default/wait-controllers: ["3m", "10s"]
   default/wait-rancher: ["15m", "30s"]
+  default/wait-capa-create-cluster: ["30m", "30s"]
   default/wait-gitea: ["3m", "10s"]
   default/wait-consistently: ["30s", "5s"]
   default/wait-getservice: ["60s", "5s"]
+  default/wait-eks-delete: ["20m", "30s"]
 
 variables:
   RANCHER_VERSION: "v2.7.6"

--- a/test/e2e/data/capi-operator/capi-providers-secret.yaml
+++ b/test/e2e/data/capi-operator/capi-providers-secret.yaml
@@ -7,4 +7,5 @@ type: Opaque
 stringData:
   CLUSTER_TOPOLOGY: "true"
   EXP_CLUSTER_RESOURCE_SET: "true"
+  EXP_MACHINE_POOL: "true"
 

--- a/test/e2e/data/capi-operator/full-providers.yaml
+++ b/test/e2e/data/capi-operator/full-providers.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capa-system
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha1
+kind: InfrastructureProvider
+metadata:
+  name: aws
+  namespace: capa-system
+spec:
+  secretName: full-variables
+  secretNamespace: default

--- a/test/e2e/data/capi-operator/full-variables.yaml
+++ b/test/e2e/data/capi-operator/full-variables.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: full-variables
+  namespace: default
+type: Opaque
+stringData:
+  AWS_B64ENCODED_CREDENTIALS: "{{ .AWSEncodedCredentials }}"
+  EXP_MACHINE_POOL: "true"
+  CAPA_LOGLEVEL: "4"
+  EXP_EXTERNAL_RESOURCE_GC: "true"

--- a/test/e2e/data/cluster-templates/aws-eks-mmp.yaml
+++ b/test/e2e/data/cluster-templates/aws-eks-mmp.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    kind: AWSManagedCluster
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: AWSManagedControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    name: "${CLUSTER_NAME}-control-plane"
+---
+kind: AWSManagedCluster
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+metadata:
+  name: "${CLUSTER_NAME}"
+  annotations:
+    "helm.sh/resource-policy": keep
+spec: {}
+---
+kind: AWSManagedControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  region: "eu-west-1"
+  version: "${KUBERNETES_VERSION}"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: "${CLUSTER_NAME}-pool-0"
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-pool-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: AWSManagedMachinePool
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSManagedMachinePool
+metadata:
+  name: "${CLUSTER_NAME}-pool-0"
+  annotations:
+    "helm.sh/resource-policy": keep
+spec: {}

--- a/test/e2e/import_gitops_test.go
+++ b/test/e2e/import_gitops_test.go
@@ -25,7 +25,7 @@ import (
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
-var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(shortTestLabel), func() {
+var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(shortTestLabel, fullTestLabel), func() {
 
 	BeforeEach(func() {
 		SetClient(bootstrapClusterProxy.GetClient())
@@ -34,21 +34,53 @@ var _ = Describe("[Docker] [Kubeadm] Create and delete CAPI cluster functionalit
 
 	CreateUsingGitOpsSpec(ctx, func() CreateUsingGitOpsSpecInput {
 		return CreateUsingGitOpsSpecInput{
-			E2EConfig:                e2eConfig,
-			BootstrapClusterProxy:    bootstrapClusterProxy,
-			ClusterctlConfigPath:     clusterctlConfigPath,
-			ClusterctlBinaryPath:     clusterctlBinaryPath,
-			ArtifactFolder:           artifactFolder,
-			ClusterTemplatePath:      "./data/cluster-templates/docker-kubeadm.yaml",
-			ClusterName:              "cluster1",
-			ControlPlaneMachineCount: ptr.To[int](1),
-			WorkerMachineCount:       ptr.To[int](1),
-			GitAddr:                  gitAddress,
-			GitAuthSecretName:        authSecretName,
-			SkipCleanup:              false,
-			SkipDeletionTest:         false,
-			LabelNamespace:           true,
-			RancherServerURL:         hostName,
+			E2EConfig:                 e2eConfig,
+			BootstrapClusterProxy:     bootstrapClusterProxy,
+			ClusterctlConfigPath:      clusterctlConfigPath,
+			ClusterctlBinaryPath:      clusterctlBinaryPath,
+			ArtifactFolder:            artifactFolder,
+			ClusterTemplatePath:       "./data/cluster-templates/docker-kubeadm.yaml",
+			ClusterName:               "cluster1",
+			ControlPlaneMachineCount:  ptr.To[int](1),
+			WorkerMachineCount:        ptr.To[int](1),
+			GitAddr:                   gitAddress,
+			GitAuthSecretName:         authSecretName,
+			SkipCleanup:               false,
+			SkipDeletionTest:          false,
+			LabelNamespace:            true,
+			RancherServerURL:          hostName,
+			CAPIClusterCreateWaitName: "wait-rancher",
+			DeleteClusterWaitName:     "wait-controllers",
+		}
+	})
+})
+
+var _ = Describe("[AWS] [EKS] Create and delete CAPI cluster functionality should work with namespace auto-import", Label(fullTestLabel), func() {
+
+	BeforeEach(func() {
+		SetClient(bootstrapClusterProxy.GetClient())
+		SetContext(ctx)
+	})
+
+	CreateUsingGitOpsSpec(ctx, func() CreateUsingGitOpsSpecInput {
+		return CreateUsingGitOpsSpecInput{
+			E2EConfig:                 e2eConfig,
+			BootstrapClusterProxy:     bootstrapClusterProxy,
+			ClusterctlConfigPath:      clusterctlConfigPath,
+			ClusterctlBinaryPath:      clusterctlBinaryPath,
+			ArtifactFolder:            artifactFolder,
+			ClusterTemplatePath:       "./data/cluster-templates/aws-eks-mmp.yaml",
+			ClusterName:               "cluster2",
+			ControlPlaneMachineCount:  ptr.To[int](1),
+			WorkerMachineCount:        ptr.To[int](1),
+			GitAddr:                   gitAddress,
+			GitAuthSecretName:         authSecretName,
+			SkipCleanup:               false,
+			SkipDeletionTest:          false,
+			LabelNamespace:            true,
+			RancherServerURL:          hostName,
+			CAPIClusterCreateWaitName: "wait-capa-create-cluster",
+			DeleteClusterWaitName:     "wait-eks-delete",
 		}
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Added a new test that will use the AWS provider. It will provision a EKS based cluster using managed node group.

Also labels have been added to the tests so that the tests can be filtered with the `--test-filter` flag when running them. This is to allow short and full tests. There are 2 constants `short` and `full` thatcan be included on the test declarations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #92 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] adds or updates e2e tests
