### PR TITLE
fix: full e2e test failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ SKIP_RESOURCE_CLEANUP ?= false
 USE_EXISTING_CLUSTER ?= false
 ISOLATED_MODE ?= false
 GINKGO_NOCOLOR ?= false
-GINKGO_LABEL_FILTER ?= "short || full"
+GINKGO_LABEL_FILTER ?= short || full
 
 # to set multiple ginkgo skip flags, if any
 ifneq ($(strip $(GINKGO_SKIP)),)


### PR DESCRIPTION
**What this PR does / why we need it**:

The full e2e test run was failing due to double escaping the label filter which caused the filter to be interpretated as a command. This change remove the quote from the filter variable value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #149 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
