### PR TITLE
🌱 chore: add dependabot go.mod check on ./test

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,26 @@
 version: 2
 updates:
+  # Main Go module
   - package-ecosystem: "gomod"
     directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "kind/cleanup"
+      - "area/dependency"
+    ignore:
+      # Ignore Cluster-API as its upgraded manually.
+      - dependency-name: "sigs.k8s.io/cluster-api"
+      # Ignore controller-runtime as its upgraded manually.
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      # Ignore k8s and its transitives modules as they are upgraded manually
+      # together with controller-runtime.
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "go.etcd.io/*"
+      - dependency-name: "google.golang.org/grpc"
+  # Test Go module
+  - package-ecosystem: "gomod"
+    directory: "/test"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot is bumping `ginkgo` in https://github.com/rancher-sandbox/rancher-turtles/pull/141 but it's only checking the main Go modules in `./`. This is not updating modules in `./test` and is causing CI failures.

This is equivalent to what's used in [cluster-api](https://github.com/kubernetes-sigs/cluster-api/blob/main/.github/dependabot.yaml).

**Which issue(s) this PR fixes**:
Fixes #154 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
