### PR TITLE
chore: change release name and generate release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,13 @@ jobs:
           mkdir -p .cr-index
 
       - name: Run chart-releaser upload
-        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --release-notes-file=RELEASE_NOTES.md
+        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ env.TAG }}" --make-release-latest false
 
       - name: Run chart-releaser index
         run: cr index --push
+
+      - name: Set release as draft # `--make-release-latest false` in cr does not seem to work
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          gh release edit ${{ env.TAG}} --draft


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the following in the release workflow:
- Updates release name, which is now prefixed by the name of the project, to only use the semver format as in `v0.0.0-rc0`.
- Sets the release as draft.
- Includes the release changelog.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #171 

**Special notes for your reviewer**:

There are a couple of things that are not exactly what I expected:
- `chart-releaser` provides a `--make-release-latest` flag that does not seem to work. The `cr upload` command is passing it as false but it keeps setting the flag to the release. To fix this, after creating the release it updates it to draft (can cause problems with previous versions).
- Tried a few user actions but wasn't able to display the release notes changelog in the same way GitHub creates it when using the UI. Even when generating release notes with GitHub CLI, it will just create a link to the changelog. Finally opted for the chart-releaser flag, which is equivalent to GitHub CLI.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
