### PR TITLE
chore: change release name in cr index push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,7 +100,7 @@ jobs:
         run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ env.TAG }}" --make-release-latest false
 
       - name: Run chart-releaser index
-        run: cr index --push
+        run: cr index --push --release-name-template "${{ env.TAG }}"
 
       - name: Set release as draft # `--make-release-latest false` in cr does not seem to work
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:

After updating the release workflow to use a different name, `cr index --push` requires to pass the name explicitly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
