### PR TITLE
🐛 Add config/namespace folder back to properly run kustomize build

### DIFF
--- a/config/namespace/kustomization.yaml
+++ b/config/namespace/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- namespace.yaml

--- a/config/namespace/namespace.yaml
+++ b/config/namespace/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
This commit adds back kustomize and namespace yaml files to config/namespace folder in order to successfully run 'kustomize build' from the config/default folder during tilt-up.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
