### PR TITLE
:bug: Disable cache timeout on discovery for delayed rancher deployment

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,8 @@ import (
 	provisioningv1 "github.com/rancher-sandbox/rancher-turtles/internal/rancher/provisioning/v1"
 )
 
+const maxDuration time.Duration = 1<<63 - 1
+
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
@@ -181,7 +183,10 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		RancherClient:      rancherClient,
 		WatchFilterValue:   watchFilterValue,
 		InsecureSkipVerify: insecureSkipVerify,
-	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: concurrencyNumber}); err != nil {
+	}).SetupWithManager(ctx, mgr, controller.Options{
+		MaxConcurrentReconciles: concurrencyNumber,
+		CacheSyncTimeout:        maxDuration,
+	}); err != nil {
 		setupLog.Error(err, "unable to create capi controller")
 		os.Exit(1)
 	}


### PR DESCRIPTION

kind/bug

**What this PR does / why we need it**:

When the rancher-turtles is installed in the cluster, but the rancher CRDs are not yet available, eventually the pod fails. Multiple restarts lead to CrashLoopBackOff, requiring a manual pod restart once rancher CRDs are installed and available in the cluster.

This *effectively* disables the cache setup timeout for resource discovery.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #180 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
