### PR TITLE
fix: use pre-install helm hook to prepare rancher for turtles

### DIFF
--- a/.github/workflows/test_chart.yaml
+++ b/.github/workflows/test_chart.yaml
@@ -8,6 +8,8 @@ env:
   MANIFEST_IMG: controller
   CONTROLLER_IMG: controller
   PULL_POLICY: Never
+  CERT_MANAGER_VERSION: v1.12.3
+  RANCHER_VERSION: v2.7.5
 
 jobs:
   lint-test:
@@ -54,9 +56,22 @@ jobs:
         uses: helm/kind-action@v1.8.0
         with:
           cluster_name: kind
+          node_image: kindest/node:v1.26.3
 
       - name: Add local docker image
         run: kind load docker-image ${{ env.MANIFEST_IMG }}:${{ env.TAG }}
+
+      - name: Add cert-manager chart repo
+        run: helm repo add jetstack https://charts.jetstack.io
+
+      - name: Add rancher chart repo
+        run: helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+
+      - name: Install cert-manager
+        run: helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${{ env.CERT_MANAGER_VERSION }} --set installCRDs=true --wait
+
+      - name: Install Rancher
+        run: helm install rancher rancher-stable/rancher --namespace cattle-system --create-namespace --set bootstrapPassword=rancheradmin --set replicas=1 --set hostname="e2e.dev.rancher" --set 'extraEnv[0].name=CATTLE_FEATURES' --set global.cattle.psp.enabled=false --version ${{ env.RANCHER_VERSION }} --wait
 
       - name: Run chart-testing (install)
         run: helm install rancher-turtles out/charts/rancher-turtles/ -n rancher-turtles-system --create-namespace --wait --set cluster-api-operator.cluster-api.enabled=false --set cluster-api-operator.enabled=false

--- a/charts/rancher-turtles/templates/pre-install-job.yaml
+++ b/charts/rancher-turtles/templates/pre-install-job.yaml
@@ -1,0 +1,99 @@
+{{- if index .Values "rancherTurtles" "features" "embedded-capi" "disabled" }}
+---
+apiVersion: management.cattle.io/v3
+kind: Feature
+metadata:
+  name: embedded-cluster-api
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+spec:
+  value: false
+{{- end }}
+{{- if index .Values "rancherTurtles" "features" "rancher-webhook" "cleanup" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pre-install-job
+  namespace: rancher-turtles-system
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pre-install-job-delete-webhooks
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pre-install-job-webhook-cleanup
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+subjects:
+  - kind: ServiceAccount
+    name: pre-install-job
+    namespace: rancher-turtles-system
+roleRef:
+  kind: ClusterRole
+  name: pre-install-job-delete-webhooks
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rancher-mutatingwebhook-cleanup
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: pre-install-job
+      containers:
+        - name: rancher-mutatingwebhook-cleanup
+          image: {{ index .Values "rancherTurtles" "features" "rancher-webhook" "kubectlImage" }}:{{ .Capabilities.KubeVersion }}
+          args:
+          - delete
+          - mutatingwebhookconfigurations.admissionregistration.k8s.io
+          - mutating-webhook-configuration
+          - --ignore-not-found=true
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rancher-validatingwebhook-cleanup
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: pre-install-job
+      containers:
+        - name: rancher-validatingwebhook-cleanup
+          image: {{ index .Values "rancherTurtles" "features" "rancher-webhook" "kubectlImage" }}:{{ .Capabilities.KubeVersion }}
+          args:
+          - delete
+          - validatingwebhookconfigurations.admissionregistration.k8s.io
+          - validating-webhook-configuration
+          - --ignore-not-found=true
+      restartPolicy: Never
+{{- end }}

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -5,6 +5,12 @@ rancherTurtles:
   namespace: rancher-turtles-system
   managerArguments: {}
   imagePullSecrets: []
+  features:
+    embedded-capi:
+      disabled: true
+    rancher-webhook:
+      cleanup: true
+      kubectlImage: rancher/kubectl
 cluster-api-operator:
   enabled: true
   cert-manager:


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, installing Rancher Turtles in an existing Rancher Manager after disabling embedded CAPI, results in validating/mutating webhooks being left behind after the feature is disabled. If you try and apply a CAPI manifest you will get an error:

```
time="2023-10-03T14:18:36Z" level=error msg="error syncing 'cluster-fleet-local-local-1a3d67d0a899/clusters-clusters': handler bundle-deploy: failed to create  │
│ resource: Internal error occurred: failed calling webhook \"default.cluster.cluster.x-k8s.io\": failed to call webhook: Post \"https://capi-webhook-service.cat/ │
│ tle-provisioning-capi-system.svc:443/mutate-cluster-x-k8s-io-v1beta1-cluster?timeout=10s\": service \"capi-webhook-service\" not found, requeuing"
```

To avoid having to manually delete these webhooks and disable the feature flag, this PR adds a `pre-install` Helm hook that:
1. Disables embedded CAPI.
2. Deletes mutating/validating webhooks (creating a Service Account, Cluster Role and Cluster Role Binding).

This is not the fanciest of solutions but it allows to install Rancher Turtles just using `helm install` in an existing Rancher Manager. We can later change Rancher and remove this hook if we find a more robust option.

**Which issue(s) this PR fixes**:
Fixes #185 

**Special notes for your reviewer**:

When this gets merged, we'll need to update the docs accordingly.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
