### PR TITLE
chore: edit cr command to not set release as latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -303,13 +303,7 @@ jobs:
           mkdir -p .cr-index
 
       - name: Run chart-releaser upload
-        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ env.TAG }}" --make-release-latest false
+        run: cr upload --skip-existing -c "$(git rev-parse HEAD)" --generate-release-notes --release-name-template "${{ env.TAG }}" --make-release-latest=false
 
       - name: Run chart-releaser index
         run: cr index --push --release-name-template "${{ env.TAG }}"
-
-      - name: Set release as draft # `--make-release-latest false` in cr does not seem to work
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run:
-          gh release edit ${{ env.TAG }} --draft


### PR DESCRIPTION
**What this PR does / why we need it**:

[chart-releaser](https://github.com/helm/chart-releaser) was setting new releases (created from GitHub Actions) as latest even though the flag `make-release-latest` was set to `false`. Apparently this was caused by the bool value not being parsed properly due to the way it was passed in the command. This very small change seems to be the proper way to do it.

With this edit, the `gh-cli` extra step to fix this at the end of the release process is no longer needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
