### PR TITLE
Always report e2e failures to slack

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -39,7 +39,7 @@ jobs:
         name: artifacts
         path: _artifacts
     - name: Send failed status to slack
-      if: failure() && github.event_name == 'schedule'
+      if: failure()
       uses: slackapi/slack-github-action@v1.23.0
       with:
         payload: |


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Before this PR failures were reported for nightly runs only, now we will be notified every time tests fail.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
