### PR TITLE
chore: add azure janitor in dry-run

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -39,6 +39,16 @@ jobs:
       with:
         name: artifacts
         path: _artifacts
+    - name: Cleanup Azure Resources
+      if: always()
+      uses: rancher-sandbox/azure-janitor@v0.1.1
+      with:
+        resource-groups: highlander-e2e*
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID}}
+        client-id: ${{ secrets.AZURE_CLIENT_ID}}
+        client-secret: ${{ secrets.AZURE_CLIENT_SECRET}}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID}}
+        commit: false
     - name: Send failed status to slack
       if: failure()
       uses: slackapi/slack-github-action@v1.24.0

--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -1,0 +1,21 @@
+name: Janitor
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  janitor:
+    name: azure-janitor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        uses: rancher-sandbox/azure-janitor@v0.1.1
+        with:
+            resource-groups: highlander-e2e*
+            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID}}
+            client-id: ${{ secrets.AZURE_CLIENT_ID}}
+            client-secret: ${{ secrets.AZURE_CLIENT_SECRET}}
+            tenant-id: ${{ secrets.AZURE_TENANT_ID}}
+            commit: false


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the Azure janitor to the nightly e2e and as a separate periodic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
