### PR TITLE
fix: check condition for controlplane ready

### DIFF
--- a/internal/controllers/import_controller.go
+++ b/internal/controllers/import_controller.go
@@ -46,6 +46,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
 
@@ -166,8 +167,9 @@ func (r *CAPIImportReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	log = log.WithValues("cluster", capiCluster.Name)
 
-	// Wait for controlplane to be ready
-	if !capiCluster.Status.ControlPlaneReady {
+	// Wait for controlplane to be ready. This should never be false as the predicates
+	// do the filtering.
+	if !capiCluster.Status.ControlPlaneReady && !conditions.IsTrue(capiCluster, clusterv1.ControlPlaneReadyCondition) {
 		log.Info("clusters control plane is not ready, requeue")
 		return ctrl.Result{RequeueAfter: defaultRequeueDuration}, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Whilst testing ClusterClass it was noticed that the status.controlplaneready field isn't being set to true. However, the condition isn't being set to true.

This change will check both the status field and the condition. If either are true then we will reconcile the CAPI cluster.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #234 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
