### PR TITLE
🌱  Run release workflow periodically

### DIFF
--- a/.github/workflows/nightly-test-release.yaml
+++ b/.github/workflows/nightly-test-release.yaml
@@ -1,0 +1,158 @@
+name: Test release process nightly
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at midnight (UTC)
+  workflow_dispatch: # Allow running manually on demand
+
+env:
+  RELEASE_TAG: t9.9.9-fake
+
+jobs:
+  nightly-test-release:
+    name: Tag current version for testing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Set and push fake tag for release
+        run: |
+          git tag ${{ env.RELEASE_TAG }}
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          tags: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-push-services:
+    name: Build, sign and provenance
+    needs: [nightly-test-release]
+    permissions:
+      actions: read
+      contents: write
+      packages: write
+      id-token: write
+    strategy:
+      matrix:
+        destination: [ghcr]
+        arch: [amd64, arm64, s390x]
+        include:
+        - destination: ghcr
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: GITHUB_TOKEN
+          image: GHCR_IMAGE
+          secret_registry: false
+    uses: ./.github/workflows/release-workflow.yml
+    with:
+      password: ${{ matrix.password }}
+      username: ${{ matrix.username }}
+      registry: ${{ matrix.registry }}
+      tag: t9.9.9-fake
+      arch: ${{ matrix.arch }}
+      image: ${{ matrix.image }}
+      secret_registry: ${{ matrix.secret_registry }}
+    secrets: inherit
+
+  multiarch:
+    name: Publish multiarch image
+    needs: [build-push-services]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      matrix:
+        destination: [ghcr]
+        include:
+        - destination: ghcr
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: GITHUB_TOKEN
+          image: GHCR_IMAGE
+          secret_registry: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ matrix.secret_registry && secrets[matrix.registry] || matrix.registry }}
+          username: ${{ matrix.secret_registry && secrets[matrix.username] || matrix.username }}
+          password: ${{ secrets[matrix.password] }}
+      - name: Publish multiarch
+        run: CONTROLLER_IMG=${{ vars[matrix.image] }} TAG=${{ env.RELEASE_TAG }} make docker-push-manifest-rancher-turtles
+
+  release:
+    name: Create helm release
+    needs: [build-push-services]
+    runs-on: ubuntu-latest
+    env:
+      PROD_REGISTRY: ${{ secrets.REGISTRY_ENDPOINT }}
+      PROD_ORG: rancher-sandbox
+      RELEASE_DIR: .cr-release-packages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+      - name: Package operator chart
+        run: RELEASE_TAG=${{ env.RELEASE_TAG }} CHART_PACKAGE_DIR=${RELEASE_DIR} REGISTRY=${{ env.PROD_REGISTRY }} ORG=${{ env.PROD_ORG }} make release
+
+  notify-failure:
+    name: Notify failure in Slack
+    needs: [release]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Rancher turtles RELEASE test failed."
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": ":github:",
+                          "emoji": true
+                        },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  clean-up:
+    name: Release testing clean up
+    needs: [release]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dev-drprasad/delete-tag-and-release@v1.0
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          delete_release: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Based on @Danil-Grigorev's work on refactoring the release process to make jobs reusable [here](https://github.com/rancher-sandbox/rancher-turtles/pull/232), this PR adds a nightly workflow (frequency can be modified if nightly is considered too often) that validates these reusable workflows by following the release process and avoiding pushing images to the production registry and publishing helm charts.

The testing workflow is based on creating a fake tag `t9.9.9-fake` (this naming is used to avoid triggering the real release action and is similar to the approach used in [upstream CAPI](https://github.com/kubernetes-sigs/cluster-api/blob/45d39d6b0bd61fd1ada3c3bc57664de5d8ad25e0/.github/workflows/weekly-test-release.yaml#L28)). The workflow then follows the build/sign/release process:
- Build images.
- Sign images.
- Create provenance.
- Build Helm chart.

The images are only pushed to GitHub Container Registry and Helm charts are created but not published.

When the action finishes, no matter the result, the testing tag is deleted so that it can be used in the next execution of the test.

If any of the steps fail to run, a notification will be sent to the Slack channel we use for nightly E2E testing alerts.

**Which issue(s) this PR fixes**:
Fixes #214 

**Special notes for your reviewer**:

~~### This PR depends on #232.~~

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
