### PR TITLE
WIP: test: avoid leaking sensitive information in e2e logs

### DIFF
--- a/test/e2e/flags.go
+++ b/test/e2e/flags.go
@@ -37,6 +37,9 @@ type FlagValues struct {
 	// HelmBinaryPath is the path to the helm binary.
 	HelmBinaryPath string
 
+	// HelmExtraValuesDir is the location where extra values files will be stored.
+	HelmExtraValuesDir string
+
 	// ChartPath is the path to the operator chart.
 	ChartPath string
 
@@ -55,6 +58,7 @@ func InitFlags(values *FlagValues) {
 	flag.BoolVar(&values.SkipCleanup, "e2e.skip-resource-cleanup", false, "if true, the resource cleanup after tests will be skipped")
 	flag.BoolVar(&values.UseExistingCluster, "e2e.use-existing-cluster", false, "if true, the test uses the current cluster instead of creating a new one (default discovery rules apply)")
 	flag.StringVar(&values.HelmBinaryPath, "e2e.helm-binary-path", "helm", "path to the helm binary")
+	flag.StringVar(&values.HelmExtraValuesDir, "e2e.helm-extra-values-path", "/tmp", "path to the extra values file")
 	flag.StringVar(&values.ClusterctlBinaryPath, "e2e.clusterctl-binary-path", "helm", "path to the clusterctl binary")
 	flag.StringVar(&values.ChartPath, "e2e.chart-path", "", "path to the operator chart")
 	flag.BoolVar(&values.IsolatedMode, "e2e.isolated-mode", false, "if true, the test will run without ngrok and exposing the cluster to the internet. This setup will only work with CAPD or other providers that run in the same network as the bootstrap cluster.")

--- a/test/e2e/suites/embedded-capi-disabled/suite_test.go
+++ b/test/e2e/suites/embedded-capi-disabled/suite_test.go
@@ -108,6 +108,7 @@ var _ = BeforeSuite(func() {
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
+		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
 		IsolatedMode:             flagVals.IsolatedMode,
 		NginxIngress:             e2e.NginxIngress,
 		NginxIngressNamespace:    e2e.NginxIngressNamespace,
@@ -125,6 +126,7 @@ var _ = BeforeSuite(func() {
 	testenv.DeployRancher(ctx, testenv.DeployRancherInput{
 		BootstrapClusterProxy:  setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:         flagVals.HelmBinaryPath,
+		HelmExtraValuesPath:    filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher.yaml"),
 		InstallCertManager:     true,
 		CertManagerChartPath:   e2eConfig.GetVariable(e2e.CertManagerPathVar),
 		CertManagerUrl:         e2eConfig.GetVariable(e2e.CertManagerUrlVar),

--- a/test/e2e/suites/import-gitops/suite_test.go
+++ b/test/e2e/suites/import-gitops/suite_test.go
@@ -108,6 +108,7 @@ var _ = BeforeSuite(func() {
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
+		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
 		IsolatedMode:             flagVals.IsolatedMode,
 		NginxIngress:             e2e.NginxIngress,
 		NginxIngressNamespace:    e2e.NginxIngressNamespace,
@@ -123,6 +124,7 @@ var _ = BeforeSuite(func() {
 	testenv.DeployRancher(ctx, testenv.DeployRancherInput{
 		BootstrapClusterProxy:  setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:         flagVals.HelmBinaryPath,
+		HelmExtraValuesPath:    filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher.yaml"),
 		InstallCertManager:     true,
 		CertManagerChartPath:   e2eConfig.GetVariable(e2e.CertManagerPathVar),
 		CertManagerUrl:         e2eConfig.GetVariable(e2e.CertManagerUrlVar),

--- a/test/e2e/suites/update-labels/suite_test.go
+++ b/test/e2e/suites/update-labels/suite_test.go
@@ -126,6 +126,7 @@ var _ = BeforeSuite(func() {
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
+		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
 		IsolatedMode:             flagVals.IsolatedMode,
 		NginxIngress:             e2e.NginxIngress,
 		NginxIngressNamespace:    e2e.NginxIngressNamespace,
@@ -141,6 +142,7 @@ var _ = BeforeSuite(func() {
 	testenv.DeployRancher(ctx, testenv.DeployRancherInput{
 		BootstrapClusterProxy:  setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:         flagVals.HelmBinaryPath,
+		HelmExtraValuesPath:    filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher.yaml"),
 		InstallCertManager:     false,
 		RancherChartRepoName:   "rancher-latest",
 		RancherChartURL:        "https://releases.rancher.com/server-charts/latest",

--- a/test/e2e/suites/v2prov/suite_test.go
+++ b/test/e2e/suites/v2prov/suite_test.go
@@ -107,6 +107,7 @@ var _ = BeforeSuite(func() {
 	testenv.RancherDeployIngress(ctx, testenv.RancherDeployIngressInput{
 		BootstrapClusterProxy:    setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:           flagVals.HelmBinaryPath,
+		HelmExtraValuesPath:      filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher-ingress.yaml"),
 		IsolatedMode:             flagVals.IsolatedMode,
 		NginxIngress:             e2e.NginxIngress,
 		NginxIngressNamespace:    e2e.NginxIngressNamespace,
@@ -122,6 +123,7 @@ var _ = BeforeSuite(func() {
 	testenv.DeployRancher(ctx, testenv.DeployRancherInput{
 		BootstrapClusterProxy:  setupClusterResult.BootstrapClusterProxy,
 		HelmBinaryPath:         flagVals.HelmBinaryPath,
+		HelmExtraValuesPath:    filepath.Join(flagVals.HelmExtraValuesDir, "deploy-rancher.yaml"),
 		InstallCertManager:     true,
 		CertManagerChartPath:   e2eConfig.GetVariable(e2e.CertManagerPathVar),
 		CertManagerUrl:         e2eConfig.GetVariable(e2e.CertManagerUrlVar),


### PR DESCRIPTION
**What this PR does / why we need it**:

While looking for an alternative solution to fix the E2E tests failing in GitHub Actions, we identified that sensitive data used for environment configuration is shown in the logs if we move to Prow. To obfuscate this information, we can populate a values file (which only exists in the container that runs the E2E, which can be considered secure).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
