### PR TITLE
chore: temporarily disable nightly e2e

### DIFF
--- a/.github/workflows/e2e-long.yaml
+++ b/.github/workflows/e2e-long.yaml
@@ -1,11 +1,11 @@
 name: Run nightly e2e tests
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
-  push:
-    branches:
-      - main
+  #schedule:
+  #  - cron: "0 0 * * *"
+  #push:
+  #  branches:
+  #    - main
   workflow_dispatch:
 
 concurrency: ci_e2e_tests


### PR DESCRIPTION
**What this PR does / why we need it**:

~~While we work on having a reliable periodic e2e test environment, this is a proposal to run the tests in isolated mode. Currently, nightly tests are not providing useful information and this would at least add limited validation in our current state. We'll be missing the cloud scenarios but at least have a meaningful validation of the logic.~~

Nightly E2E tests are disables until the test environment is stable and output messages are relevant.

**Special notes for your reviewer**:

- Current nightly E2E tests are disabled.
- ~~The short variant of the E2E tests is executed nightly and on push to main, temporarily.~~

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
