### PR TITLE
WIP: chore: add ci script for e2e testing

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -38,3 +38,24 @@ EOF
         return 2
     fi
 }
+
+turtles::utils::ensure_ngrok_envs() {
+    : "${NGROK_AUTHTOKEN:?Environment variable empty or not defined.}"
+    : "${NGROK_API_KEY:?Environment variable empty or not defined.}"
+}
+
+turtles::utils::ensure_rancher_envs() {
+    : "${RANCHER_HOSTNAME:?Environment variable empty or not defined.}"
+    : "${RANCHER_PASSWORD:?Environment variable empty or not defined.}"
+}
+
+turtles::utils::ensure_azure_envs() {
+    : "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
+    : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
+    : "${AZURE_CLIENT_ID:?Environment variable empty or not defined.}"
+    : "${AZURE_CLIENT_SECRET:?Environment variable empty or not defined.}"
+}
+
+turtles::utils::ensure_aws_envs() {
+    : "${CAPA_ENCODED_CREDS:?Environment variable empty or not defined.}"
+}

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+################################################################################
+# usage: ./ci-e2e.sh
+#  This program runs the e2e tests.
+#  It is automatically triggered by Rancher Turtles CI system.
+#
+# If you want to run it locally, you'll need to export the following environment variables:
+#    - Ngrok:   NGROK_AUTHTOKEN, NGROK_API_KEY
+#    - Rancher: RANCHER_HOSTNAME, RANCHER_PASSWORD
+#    - Azure:   AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET
+#    - AWS:     CAPA_ENCODED_CREDS
+#
+################################################################################
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+# shellcheck source=hack/utils.sh
+source "${REPO_ROOT}/hack/utils.sh"
+
+# Verify the required environment variables
+turtles::utils::ensure_ngrok_envs
+turtles::utils::ensure_rancher_envs
+turtles::utils::ensure_azure_envs
+turtles::utils::ensure_aws_envs
+
+# Run E2E
+make test-e2e
+
+# Run janitors
+# Azure janitor
+#
+# AWS janitor
+#


### PR DESCRIPTION
**What this PR does / why we need it**:

Based on the configuration used in upstream projects, e.g. [CAPA](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/scripts/ci-e2e.sh), and setting up E2E tests running periodically in Prow as a PoC (which hopefully solves the current stability of nightly tests and can be promoted to full-time solution), this PR adds a script used to trigger the full E2E test suite.

In the future, if required, this script can include the logic to interact with [boskos](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/b003e69199b3b598a1c0f26a5726466d0a331fb7/scripts/ci-e2e.sh#L54) and run the janitors.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
