### PR TITLE
chore: send alarm message when release test is cancelled

### DIFF
--- a/.github/workflows/nightly-test-release.yaml
+++ b/.github/workflows/nightly-test-release.yaml
@@ -110,7 +110,7 @@ jobs:
   notify-failure:
     name: Notify failure in Slack
     needs: [release]
-    if: failure()
+    if: ${{ failure() || cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: slackapi/slack-github-action@v1.24.0


### PR DESCRIPTION
**What this PR does / why we need it**:

The first few executions of the nightly release test are cancelled after one of the re-used workflows fails which causes a cancelled status and not a failure. The notification job in the workflow is only configured to run if `failure()` and this PR adds the `cancelled()` state to the condition to get notified when this occurs.

**Which issue(s) this PR fixes**:
Fixes #269 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
