### PR TITLE
fix: nightly release test failing to sign images

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag }}
       - name: Build the image
         id: image
         uses: ./.github/workflows/release_build
@@ -80,6 +81,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag }}
       - name: Sign image with cosign
         uses: ./.github/workflows/release_sign
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

The recently introduced nightly test release is not failing when signing the image. @Danil-Grigorev identified the cause of error as this workflow is not triggered by a new tag but periodically and hence the checkout during signing was referencing `refs/remotes/origin/main` and not the testing tag `refs/tags/v9.9.9-fake`.

This PR adds an explicit `ref` key to the checkout steps in `build` and `sign`. This should force the periodic workflow to use the proper tag and should not alter the behavior when creating an actual release.

**Which issue(s) this PR fixes**:
Fixes #272 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
