### PR TITLE
fix: cosign verify for release test workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           image: ${{ format('{0}-{1}', vars[inputs.image], inputs.arch) }}
           digest: ${{ needs.build.outputs.digest }}
-          identity: https://github.com/${{ inputs.org }}/rancher-turtles/.github/workflows/release-workflow.yml@refs/tags/${{ inputs.tag }}
+          identity: https://github.com/${{ inputs.org }}/rancher-turtles/.github/workflows/release-workflow.yml@${{ github.ref }}
           oids-issuer: https://token.actions.githubusercontent.com
           registry: ${{ inputs.secret_registry && secrets[inputs.registry] || inputs.registry }}
           username: ${{ inputs.secret_registry && secrets[inputs.username] || inputs.username }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The changes introduced with #273 have not solved the issue of the nightly test release workflow verifying the signed images with `cosign`. After some investigation together with @Danil-Grigorev, the error in the verification seems to be related to the way the action authenticates against cosign for signing. It populates a subject in the signing data that is based on the ref/email (refer to [this](https://github.com/sigstore/cosign#sign-a-container-and-store-the-signature-in-the-registry)):
- If the release is triggered by a tag creation (our release procedure), the subject will be, for example, `https://github.com/rancher-sandbox/rancher-turtles/.github/workflows/release-workflow.yml@refs/tags/v0.0.0` which must match the `--certificate-identity` passed to `cosign verify`.
- In the case of the test release, the action is not triggered by a tag creation but periodically (to easily keep track of the job status), this causes `cosign sign` to use a subject based on the branch rather than the tag, for example, `https://github.com/rancher-sandbox/rancher-turtles/.github/workflows/release-workflow.yml@refs/heads/main`. This would then not pass the verification step which would be expecting a `--certificate-identity` based on the tag.

This PR changes the `identity` variable passed to the signing reusable workflow to set the full ref and not only the tag.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
