### PR TITLE
fix: pin capz versions in e2e tests

### DIFF
--- a/test/e2e/data/capi-operator/full-providers.yaml
+++ b/test/e2e/data/capi-operator/full-providers.yaml
@@ -26,3 +26,4 @@ metadata:
 spec:
   secretName: azure-variables
   secretNamespace: default
+  version: v1.11.5


### PR DESCRIPTION
**What this PR does / why we need it**:

This change pins the CAPZ version to v1.11.5 for E2E tests. A new issue has been created to track why latest version is not provisioning AKS clusters #281.

**Which issue(s) this PR fixes**:
Fixes #198 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
