### PR TITLE
fix: #280 strip kubernetes version

### DIFF
--- a/charts/rancher-turtles/templates/_helpers.tpl
+++ b/charts/rancher-turtles/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{/*
+    This removes the part after the + in the kubernetes version string.
+    v1.27.4+k3s1 -> v1.27.4
+    v1.28.0 -> v1.28.0
+*/}}
+{{- define "strippedKubeVersion" -}}
+{{- $parts := split "+" .Capabilities.KubeVersion.Version -}}
+{{- print $parts._0 -}}
+{{- end -}}

--- a/charts/rancher-turtles/templates/pre-install-job.yaml
+++ b/charts/rancher-turtles/templates/pre-install-job.yaml
@@ -67,7 +67,7 @@ spec:
       serviceAccountName: pre-install-job
       containers:
         - name: rancher-mutatingwebhook-cleanup
-          image: {{ index .Values "rancherTurtles" "features" "rancher-webhook" "kubectlImage" }}:{{ .Capabilities.KubeVersion }}
+          image: {{ index .Values "rancherTurtles" "features" "rancher-webhook" "kubectlImage" }}:{{ template "strippedKubeVersion" . }}
           args:
           - delete
           - mutatingwebhookconfigurations.admissionregistration.k8s.io
@@ -89,7 +89,7 @@ spec:
       serviceAccountName: pre-install-job
       containers:
         - name: rancher-validatingwebhook-cleanup
-          image: {{ index .Values "rancherTurtles" "features" "rancher-webhook" "kubectlImage" }}:{{ .Capabilities.KubeVersion }}
+          image: {{ index .Values "rancherTurtles" "features" "rancher-webhook" "kubectlImage" }}:{{ template "strippedKubeVersion" . }}
           args:
           - delete
           - validatingwebhookconfigurations.admissionregistration.k8s.io


### PR DESCRIPTION
kind/bug

**What this PR does / why we need it**:

currently the postinstall jobs `rancher-mutatingwebhook-cleanup` and `rancher-validatingwebhook-cleanup` fail.
The rancher/kubectl images only have the "normal" kubernetes version, the extra part for rke2/k3s extension has to be removed

v1.26.8+rke2r1 has to formatted to v1.26.8

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #280 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
