### PR TITLE
test: allow limiting which suites are run

### DIFF
--- a/.github/workflows/e2e-long-test.yaml
+++ b/.github/workflows/e2e-long-test.yaml
@@ -17,7 +17,8 @@ env:
   AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
 jobs:
-  e2e:
+  e2e_import_gitops:
+    name: E2E Tests - Import Gitops
     runs-on: [self-hosted, linux]
     steps:
     - name: Checkout
@@ -29,7 +30,100 @@ jobs:
       with:
         go-version: '=1.20.7'
     - name: Run e2e tests
-      run: make test-e2e
+      run: GINKGO_TESTS=$(pwd)/test/e2e/suites/import-gitops make test-e2e
+    - name: Collect run artifacts
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: artifacts
+        path: _artifacts
+    - name: Cleanup Azure Resources
+      if: always()
+      uses: rancher-sandbox/azure-janitor@v0.1.1
+      with:
+        resource-groups: highlander-e2e*
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID}}
+        client-id: ${{ secrets.AZURE_CLIENT_ID}}
+        client-secret: ${{ secrets.AZURE_CLIENT_SECRET}}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID}}
+        commit: true
+  e2e_v2prov:
+    name: E2E Tests - v2prov
+    runs-on: [self-hosted, linux]
+    needs: e2e_import_gitops
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: setupGo
+      uses: actions/setup-go@v4
+      with:
+        go-version: '=1.20.7'
+    - name: Run e2e tests
+      run: GINKGO_TESTS=$(pwd)/test/e2e/suites/v2prov make test-e2e
+    - name: Collect run artifacts
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: artifacts
+        path: _artifacts
+    - name: Cleanup Azure Resources
+      if: always()
+      uses: rancher-sandbox/azure-janitor@v0.1.1
+      with:
+        resource-groups: highlander-e2e*
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID}}
+        client-id: ${{ secrets.AZURE_CLIENT_ID}}
+        client-secret: ${{ secrets.AZURE_CLIENT_SECRET}}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID}}
+        commit: true
+  e2e_update_labels:
+    name: E2E Tests - Update labels
+    runs-on: [self-hosted, linux]
+    needs: e2e_v2prov
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: setupGo
+      uses: actions/setup-go@v4
+      with:
+        go-version: '=1.20.7'
+    - name: Run e2e tests
+      run: GINKGO_TESTS=$(pwd)/test/e2e/suites/update-labels make test-e2e
+    - name: Collect run artifacts
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: artifacts
+        path: _artifacts
+    - name: Cleanup Azure Resources
+      if: always()
+      uses: rancher-sandbox/azure-janitor@v0.1.1
+      with:
+        resource-groups: highlander-e2e*
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID}}
+        client-id: ${{ secrets.AZURE_CLIENT_ID}}
+        client-secret: ${{ secrets.AZURE_CLIENT_SECRET}}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID}}
+        commit: true
+  e2e_embedded_capi_disabled:
+    name: E2E Tests - Embedded CAPI Disabled
+    runs-on: [self-hosted, linux]
+    needs: e2e_update_labels
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: setupGo
+      uses: actions/setup-go@v4
+      with:
+        go-version: '=1.20.7'
+    - name: Run e2e tests
+      run: GINKGO_TESTS=$(pwd)/test/e2e/suites/embedded-capi-disabled make test-e2e
     - name: Collect run artifacts
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e-short-test.yaml
+++ b/.github/workflows/e2e-short-test.yaml
@@ -1,0 +1,25 @@
+name: Run short e2e tests (with runner)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: [self-hosted, linux]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: setupGo
+      uses: actions/setup-go@v4
+      with:
+        go-version: '=1.20.7'
+    - name: Run e2e tests
+      run: ISOLATED_MODE=true GINKGO_LABEL_FILTER=short make test-e2e
+    - name: Collect run artifacts
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: artifacts
+        path: _artifacts

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ USE_EXISTING_CLUSTER ?= false
 ISOLATED_MODE ?= false
 GINKGO_NOCOLOR ?= false
 GINKGO_LABEL_FILTER ?= short || full
+GINKGO_TESTS ?= $(ROOT_DIR)/$(TEST_DIR)/e2e/suites/...
 
 # to set multiple ginkgo skip flags, if any
 ifneq ($(strip $(GINKGO_SKIP)),)
@@ -492,7 +493,7 @@ test-e2e: $(GINKGO) $(HELM) $(CLUSTERCTL) kubectl e2e-image ## Run the end-to-en
 	$(GINKGO) -v --trace -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) \
 		-poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) --tags=e2e --focus="$(GINKGO_FOCUS)" --label-filter="$(GINKGO_LABEL_FILTER)" \
 		$(_SKIP_ARGS) --nodes=$(GINKGO_NODES) --timeout=$(GINKGO_TIMEOUT) --no-color=$(GINKGO_NOCOLOR) \
-		--output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" $(GINKGO_ARGS) $(ROOT_DIR)/$(TEST_DIR)/e2e/suites/... -- \
+		--output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" $(GINKGO_ARGS) $(GINKGO_TESTS) -- \
 	    -e2e.artifacts-folder="$(ARTIFACTS)" \
 	    -e2e.config="$(E2E_CONF_FILE)" \
 		-e2e.helm-binary-path=$(HELM) \


### PR DESCRIPTION
**What this PR does / why we need it**:

Small change to allow you to run a specific suite when running tests and splits up the self-hosted runner test into a step per e2e suite.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
