### PR TITLE
🐛 Variable secrets should be created in existing namespaces

### DIFF
--- a/test/e2e/data/capi-operator/capa-variables.yaml
+++ b/test/e2e/data/capi-operator/capa-variables.yaml
@@ -1,3 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capa-system
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/test/e2e/data/capi-operator/capz-identity-secret.yaml
+++ b/test/e2e/data/capi-operator/capz-identity-secret.yaml
@@ -1,8 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capz-system
+---
 apiVersion: v1
 stringData:
   clientSecret: "${AZURE_CLIENT_SECRET}"
 kind: Secret
 metadata:
   name: cluster-identity-secret
-  namespace: default
+  namespace: capz-system
 type: Opaque

--- a/test/e2e/data/capi-operator/full-providers.yaml
+++ b/test/e2e/data/capi-operator/full-providers.yaml
@@ -1,14 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: capa-system
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: capz-system
----
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

kind/bug 

**What this PR does / why we need it**:
Secrets are created before the providers, so the namespaces should be created together in an e2e test run.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
