### PR TITLE
[Release 0.4] fix: installation on eks

### DIFF
--- a/charts/rancher-turtles/templates/_helpers.tpl
+++ b/charts/rancher-turtles/templates/_helpers.tpl
@@ -1,9 +1,22 @@
 {{/*
     This removes the part after the + in the kubernetes version string.
     v1.27.4+k3s1 -> v1.27.4
+    v1.26.12-eks-5e0fdde -> v1.26.12
+    v1.26.12-gke.1 -> v1.26.12
     v1.28.0 -> v1.28.0
 */}}
 {{- define "strippedKubeVersion" -}}
-{{- $parts := split "+" .Capabilities.KubeVersion.Version -}}
-{{- print $parts._0 -}}
+    {{- if (.Capabilities.KubeVersion.Version | contains "-eks-") -}}
+        {{- $parts := split "-eks-" .Capabilities.KubeVersion.Version -}}
+        {{- print $parts._0 -}}
+    {{- else if (.Capabilities.KubeVersion.Version | contains "-gke.") -}}
+        {{- $parts := split "-gke." .Capabilities.KubeVersion.Version -}}
+        {{- print $parts._0 -}}
+    {{- else if (.Capabilities.KubeVersion.Version | contains "-aks") -}}
+        {{- $parts := split "-aks" .Capabilities.KubeVersion.Version -}}
+        {{- print $parts._0 -}}
+    {{- else -}}
+        {{- $parts := split "+" .Capabilities.KubeVersion.Version -}}
+        {{- print $parts._0 -}}
+    {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:

There is an issue installing Rancher Turtles on EKS using the chart as the kubernetes version in EKS doesn't follow semver. For example, EKS will return a version like `v1.26.12-eks-5e0fdde` and this means that we then try and pull the `docker.io/rancher/kubectl:v1.26.12-eks-5e0fdde` image when performing the cleanup tasks.

The function to strip the suffix from the kubernetes version has been updated to handle EKS, AKS and GKE.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates #347

**Special notes for your reviewer**:

This is a cherry-pick from main.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes

