### PR TITLE
docs: managementv3 cluster support strategy

### DIFF
--- a/docs/adr/0008-managementv3-clusters-support.md
+++ b/docs/adr/0008-managementv3-clusters-support.md
@@ -1,0 +1,51 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [8. Management V3 clusters support](#8-management-v3-clusters-support)
+  - [Context](#context)
+  - [Decision](#decision)
+  - [Consequences](#consequences)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# 8. Management V3 clusters support
+
+* Status: proposed
+* Date: 2024-01-25
+* Authors: @salasberryfin
+* Deciders: @richardcase @alexander-demicev @furkatgofurov7 @Danil-Grigorev @mjura
+
+## Context
+
+As an operator, I'd like to have an alternative import strategy that will generate a `management.cattle.io/v3` cluster instead of a `provisioning.cattle.io/v1` cluster. This is to ensure that we can support this scenario in light of future changes to Rancher.
+
+## Decision
+
+The current import controller logic creates a `provisioning.cattle.io/v1` cluster when a new CAPI cluster is detected. To support a new import strategy, based on a new feature flag, Rancher Turtles will either start the existing `provisioning.cattle.io` controller or a new one for `management.cattle.io`.
+
+Adding support for this resource presents some challenges:
+- Owner Reference cannot be set: `management.cattle.io/v3` clusters are cluster-scoped while CAPI clusters are namespaced.
+- Display name and resource name are different.
+- Cluster registration token exists in a namespace with the same name as the `management.cattle.io/v3` cluster.
+
+Of all three, the naming strategy is the main concern. The `GenerateName` field allows us to set a prefix `c-` and automatically assigns a random name that satisfies the regular expression.
+
+Using this random name approach, we cannot rely on `Name` and `Namespace` to be able to control the status of the cluster during reconciliation, as we do in the existing import controller. After validation, the decision is that we set labels on the Rancher clusters that make it possible to link them back to the underlying CAPI cluster. The labels are:
+
+```
+"cluster-api.cattle.io/capi-cluster-owner": name of the CAPI cluster.
+"cluster-api.cattle.io/capi-cluster-owner-ns": namespace of the CAPI cluster.
+```
+
+These two labels allow us to uniquely identify each Rancher cluster, since only one CAPI cluster with a given name can exist in a given namespace. During the reconciliation process, we apply a `MatchingLabels` filter to strictly retrieve only the single cluster that contains the labels that associate it with the CAPI cluster.
+
+From an end-user perspective:
+
+* The default behavior remains unchanged. If no feature flag is set, the current `provisioning.cattle.io` import strategy will be used.
+* User provided name will be used in Rancher dashboard while the underlying `management.cattle.io/v3` will have a name that satisfies Rancher's naming requirement: `c-` followed by 5 randomly-generated characters.
+
+## Consequences
+
+- Kubernetes' native garbage collector using the owner reference chain is not a viable option due to the namespaced vs global scoped conflict. This means that there needs to be a custom logic to manage deletion of resources.
+- Cluster name will be used to access cluster registration token namespace.
+- Display name and cluster name will be different.


### PR DESCRIPTION
**What this PR does / why we need it**:

This ADR is a proposal on how support for `management.cattle.io/v3` clusters is implemented, based on investigation during the development process. 

**The main point of concern here is how we manage cluster naming**. Since `management.cattle.io/v3` clusters are required to have a name that satisfies the string `c-` followed by exactly five characters, we cannot use the display name (the one that appears in Rancher dashboard) as we do with `provisioning.cattle.io/v1` clusters (where name and display name are the same).

Creating a randomized 5-character suffix presents the challenge of not being able to track the resource while reconciling like we do in the existing `provisioning.cattle.io/v1` import controller, since we fetch the cluster on `Name` and `Namespace` (refer to [here](https://github.com/rancher-sandbox/rancher-turtles/blob/8109fda7fe2d77f549ea03fcb0c9b2095e5dd55a/internal/controllers/import_controller.go#L199)).

~A reasonable alternative is to compute the SHA256 hash of the display name and then truncate the result to fit in the 5-character prefix of the name. This would make it easy and cheap to deterministically get the resource name based on the display name. The problem with this approach is that we could potentially encounter collisions if the number of clusters is large.~

We will be tracking the cluster based on two new labels that will be applied to all `management.cattle.io/v3` Rancher clusters that uniquely reference the CAPI cluster that owns the resource. Using this approach, we can leverage the built-in functionality of Kubernetes by passing the field `GenerateName` with the prefix `c-` so that it randomly generates a 5 character suffix that satisfies the regular expression, and retries if a name collision occurs.


**Which issue(s) this PR fixes**:
Fixes #361 

**Special notes for your reviewer**:

**Checklist**:

- [ ] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
