### PR TITLE
chore: e2e environment with fixed capd version

### DIFF
--- a/test/e2e/data/capi-operator/capi-providers.yaml
+++ b/test/e2e/data/capi-operator/capi-providers.yaml
@@ -12,5 +12,6 @@ metadata:
 spec:
   name: docker
   type: infrastructure
+  version: v1.4.6
   configSecret:
     name: variables


### PR DESCRIPTION
**What this PR does / why we need it**:

This prevents us from having a test environment with mismatched capi core and capd versions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
