### PR TITLE
🪴 Rancher credentials lookup by namespace name

### DIFF
--- a/api/v1alpha1/capiprovider_types.go
+++ b/api/v1alpha1/capiprovider_types.go
@@ -79,12 +79,16 @@ type Features struct {
 // Credentials defines the external credentials information for the provider.
 // +kubebuilder:validation:MaxProperties=1
 // +kubebuilder:validation:MinProperties=1
+// +kubebuilder:validation:XValidation:message="rancherCloudCredentialNamespaceName should be in the namespace:name format.",rule="!has(self.rancherCloudCredentialNamespaceName) || self.rancherCloudCredentialNamespaceName.matches('^.+:.+$')"
 // +structType=atomic
 //
 //nolint:godot
 type Credentials struct {
 	// RancherCloudCredential is the Rancher Cloud Credential name
 	RancherCloudCredential string `json:"rancherCloudCredential,omitempty"`
+
+	// RancherCloudCredentialNamespaceName is the Rancher Cloud Credential namespace:name reference
+	RancherCloudCredentialNamespaceName string `json:"rancherCloudCredentialNamespaceName,omitempty"`
 
 	// +optional
 	// TODO: decide how to handle workload identity

--- a/api/v1alpha1/capiprovider_types.go
+++ b/api/v1alpha1/capiprovider_types.go
@@ -83,6 +83,7 @@ type Features struct {
 // +structType=atomic
 //
 //nolint:godot
+//nolint:lll
 type Credentials struct {
 	// RancherCloudCredential is the Rancher Cloud Credential name
 	RancherCloudCredential string `json:"rancherCloudCredential,omitempty"`

--- a/charts/rancher-turtles/templates/rancher-turtles-components.yaml
+++ b/charts/rancher-turtles/templates/rancher-turtles-components.yaml
@@ -101,8 +101,16 @@ spec:
                     description: RancherCloudCredential is the Rancher Cloud Credential
                       name
                     type: string
+                  rancherCloudCredentialNamespaceName:
+                    description: RancherCloudCredentialNamespaceName is the Rancher
+                      Cloud Credential namespace:name reference
+                    type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: rancherCloudCredentialNamespaceName should be in the namespace:name
+                    format.
+                  rule: '!has(self.rancherCloudCredentialNamespaceName) || self.rancherCloudCredentialNamespaceName.matches(''^.+:.+$'')'
               deployment:
                 description: Deployment defines the properties that can be enabled
                   on the deployment for the provider.

--- a/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
+++ b/config/crd/bases/turtles-capi.cattle.io_capiproviders.yaml
@@ -102,8 +102,16 @@ spec:
                     description: RancherCloudCredential is the Rancher Cloud Credential
                       name
                     type: string
+                  rancherCloudCredentialNamespaceName:
+                    description: RancherCloudCredentialNamespaceName is the Rancher
+                      Cloud Credential namespace:name reference
+                    type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: rancherCloudCredentialNamespaceName should be in the namespace:name
+                    format.
+                  rule: '!has(self.rancherCloudCredentialNamespaceName) || self.rancherCloudCredentialNamespaceName.matches(''^.+:.+$'')'
               deployment:
                 description: Deployment defines the properties that can be enabled
                   on the deployment for the provider.

--- a/internal/sync/secret_mapper_sync.go
+++ b/internal/sync/secret_mapper_sync.go
@@ -233,15 +233,16 @@ func (SecretMapperSync) Template(capiProvider *turtlesv1.CAPIProvider) client.Ob
 // Get retrieves the source Rancher secret and destenation secret.
 func (s *SecretMapperSync) Get(ctx context.Context) error {
 	log := log.FromContext(ctx)
-
 	secretList := &corev1.SecretList{}
+
 	if s.Source.Spec.Credentials.RancherCloudCredentialNamespaceName != "" {
 		err := s.client.Get(ctx, client.ObjectKeyFromObject(s.RancherSecret), s.RancherSecret)
 		if err == nil {
 			return s.SecretSync.Get(ctx)
 		}
 
-		log.Error(err, fmt.Sprintf("Unable to get source rancher secret by reference, looking for: %s", client.ObjectKeyFromObject(s.RancherSecret).String()))
+		log.Error(err, fmt.Sprintf("Unable to get source rancher secret by reference, looking for: %s",
+			client.ObjectKeyFromObject(s.RancherSecret).String()))
 	} else if err := s.client.List(ctx, secretList, client.InNamespace(RancherCredentialsNamespace)); err != nil {
 		log.Error(err, fmt.Sprintf("Unable to list source rancher secrets, looking for: %s", client.ObjectKeyFromObject(s.RancherSecret).String()))
 
@@ -334,10 +335,12 @@ func Into(provider string, from map[string][]byte, to map[string]string) error {
 // If no argument is non-zero, it returns the zero value.
 func Or[T comparable](vals ...T) T {
 	var zero T
+
 	for _, val := range vals {
 		if val != zero {
 			return val
 		}
 	}
+
 	return zero
 }


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Implementing a separate field for a fully qualified `namespace:name` reference to the rancher cloud credentials secret, as an alternative to the name annotation.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #386 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
