### PR TITLE
👾 Add dependabot rule to bump CAPI Operator dependency as early as possible

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,8 +13,9 @@ updates:
         patterns:
           - "*"
     ignore:
-      # Ignore Cluster-API as its upgraded manually.
+      # Ignore Cluster-API as its upgraded separately.
       - dependency-name: "sigs.k8s.io/cluster-api"
+      - dependency-name: "sigs.k8s.io/cluster-api-operator"
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
       # Ignore k8s and its transitives modules as they are upgraded manually
@@ -22,6 +23,18 @@ updates:
       - dependency-name: "k8s.io/*"
       - dependency-name: "go.etcd.io/*"
       - dependency-name: "google.golang.org/grpc"
+  # Watch CAPI Operator changes daily for a timely version bump.
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "kind/cleanup"
+      - "area/dependency"
+    groups:
+      dependencies:
+        patterns:
+          - "sigs.k8s.io/cluster-api-operator"
   # Test Go module
   - package-ecosystem: "gomod"
     directory: "/test"


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
With this change we will get dependency bump early (which can be just a notification in case of incompatible changes), including CAPI version and CAPI Operator version for CAPIProvider implementation.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #384 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
