### PR TITLE
✨ Re-apply capi infra periodically

### DIFF
--- a/api/v1alpha1/conditions_consts.go
+++ b/api/v1alpha1/conditions_consts.go
@@ -27,4 +27,7 @@ const (
 
 	// RancherCredentialSourceMissing occures when a source credential secret is missing.
 	RancherCredentialSourceMissing = "RancherCredentialSourceMissing"
+
+	// LastAppliedConfigurationTime is set as a timestamp infor of the last configuration update byt the CAPI Operator resource.
+	LastAppliedConfigurationTime = "LastAppliedConfigurationTime"
 )

--- a/charts/rancher-turtles/Chart.yaml
+++ b/charts/rancher-turtles/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
 - provisioning
 dependencies:
   - name: cluster-api-operator
-    version: v0.8.1
+    version: v0.9.0
     repository: https://kubernetes-sigs.github.io/cluster-api-operator
     condition: cluster-api-operator.enabled
 annotations:

--- a/internal/sync/provider_sync.go
+++ b/internal/sync/provider_sync.go
@@ -31,6 +31,8 @@ import (
 	"github.com/rancher-sandbox/rancher-turtles/internal/api"
 )
 
+// AppliedSpecHashAnnotation is a spec hash annotation set by CAPI Operator,
+// to prevent infrastructure rollout without spec changes.
 const AppliedSpecHashAnnotation = "operator.cluster.x-k8s.io/applied-spec-hash"
 
 // ProviderSync is a structure mirroring state of the CAPI Operator Provider object.
@@ -131,6 +133,7 @@ func (s *ProviderSync) rolloutInfrastructure() {
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
+
 	annotations[AppliedSpecHashAnnotation] = ""
 	s.Destination.SetAnnotations(annotations)
 

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -6,7 +6,7 @@ images:
   loadBehavior: tryLoad
 
 intervals:
-  default/wait-controllers: ["3m", "10s"]
+  default/wait-controllers: ["15m", "10s"]
   default/wait-rancher: ["15m", "30s"]
   default/wait-v2prov-create: ["25m", "30s"]
   default/wait-capa-create-cluster: ["30m", "30s"]


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This implementation adds `LastAppliedConfigurationTime` to `CAPIProvider` conditions, to reflect last update time for the infrastructure. To make it work, when the condition is outdated (more then 5 minutes old), then the `operator.cluster.x-k8s.io/applied-spec-hash` annotation on the provisioned CAPI Operator resource gets updated to empty value. This causes CAPI Operator to validate and update the provisioned infrastructure objects in case of a difference with repository content.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #348 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted --

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
