### PR TITLE
:bug: Fix dependabot duplicate rule issue

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "kind/cleanup"
       - "area/dependency"
@@ -15,7 +15,6 @@ updates:
     ignore:
       # Ignore Cluster-API as its upgraded separately.
       - dependency-name: "sigs.k8s.io/cluster-api"
-      - dependency-name: "sigs.k8s.io/cluster-api-operator"
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
       # Ignore k8s and its transitives modules as they are upgraded manually
@@ -23,18 +22,6 @@ updates:
       - dependency-name: "k8s.io/*"
       - dependency-name: "go.etcd.io/*"
       - dependency-name: "google.golang.org/grpc"
-  # Watch CAPI Operator changes daily for a timely version bump.
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "kind/cleanup"
-      - "area/dependency"
-    groups:
-      dependencies:
-        patterns:
-          - "sigs.k8s.io/cluster-api-operator"
   # Test Go module
   - package-ecosystem: "gomod"
     directory: "/test"


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Apparently dependabot does not support separation of groups for the same dependency engine (gomod). 

https://github.com/rancher-sandbox/rancher-turtles/runs/21812211327

`The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'`

The problem appears to be due to: https://github.com/dependabot/dependabot-core/issues/1778

To still benefit from early CAPI Operator version bump, changing interval to daily.