### PR TITLE
✨ Pin installed versions for CAPI Operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,7 +471,7 @@ $(HELM): ## Put helm into tools folder.
 	rm -f $(TOOLS_BIN_DIR)/get_helm.sh
 
 $(CLUSTERCTL): $(TOOLS_BIN_DIR) ## Download and install clusterctl
-	curl --retry $(CURL_RETRIES) -fsSL -o $(CLUSTERCTL) https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.6/clusterctl-linux-amd64
+	curl --retry $(CURL_RETRIES) -fsSL -o $(CLUSTERCTL) https://github.com/kubernetes-sigs/cluster-api/releases/download/$(CLUSTERCTL_VER)/clusterctl-linux-amd64
 	chmod +x $(CLUSTERCTL)
 
 ## --------------------------------------

--- a/charts/rancher-turtles/questions.yml
+++ b/charts/rancher-turtles/questions.yml
@@ -45,8 +45,3 @@ questions:
     description: "Flag to enable or disable installation of cert-manager. If set to false then you will need to install cert-manager manually"
     label: "Enable Cert Manager"
     type: boolean
-  - variable: cluster-api-operator.cluster-api.version
-    default: "v1.4.6"
-    required: true
-    description: "Version of the core CAPI controllers to install."
-    label: "Version"

--- a/charts/rancher-turtles/templates/clusterctl-config.yaml
+++ b/charts/rancher-turtles/templates/clusterctl-config.yaml
@@ -1,0 +1,50 @@
+{{- if index .Values "cluster-api-operator" "enabled" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clusterctl-config
+  namespace: '{{ .Values.rancherTurtles.namespace }}'
+data:
+  clusterctl.yaml: |
+    providers:
+    # Cluster API core provider
+    - name:         "cluster-api"
+      url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.6.2/core-components.yaml"
+      type:         "CoreProvider"
+
+    # Infrastructure providers
+    - name:         "aws"
+      url:          "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/v2.3.5/infrastructure-components.yaml"
+      type:         "InfrastructureProvider"
+    - name:         "azure"
+      url:          "https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/v1.13.2/infrastructure-components.yaml"
+      type:         "InfrastructureProvider"
+    - name:         "docker"
+      url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.6.2/infrastructure-components-development.yaml"
+      type:         "InfrastructureProvider"
+    - name:         "gcp"
+      url:          "https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/v1.6.0/infrastructure-components.yaml"
+      type:         "InfrastructureProvider"
+    - name:         "vsphere"
+      url:          "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/v1.9.1/infrastructure-components.yaml"
+      type:         "InfrastructureProvider"
+    - name:         "digitalocean"
+      url:          "https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/releases/v1.4.1/infrastructure-components.yaml"
+      type:         "InfrastructureProvider"
+
+    # Bootstrap providers
+    - name:         "kubeadm"
+      url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.6.2/bootstrap-components.yaml"
+      type:         "BootstrapProvider"
+    - name:         "rke2"
+      url:          "https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/v0.2.6/bootstrap-components.yaml"
+      type:         "BootstrapProvider"
+
+    # ControlPlane providers
+    - name:         "kubeadm"
+      url:          "https://github.com/kubernetes-sigs/cluster-api/releases/v1.6.2/control-plane-components.yaml"
+      type:         "ControlPlaneProvider"
+    - name:         "rke2"
+      url:          "https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/v0.2.6/control-plane-components.yaml"
+      type:         "ControlPlaneProvider"
+{{- end }}

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -35,7 +35,6 @@ cluster-api-operator:
         readOnly: true
   cluster-api:
     enabled: true
-    version: v1.4.6
     configSecret:
       name: ""
       defaultName: capi-env-variables

--- a/charts/rancher-turtles/values.yaml
+++ b/charts/rancher-turtles/values.yaml
@@ -17,6 +17,22 @@ cluster-api-operator:
   enabled: true
   cert-manager:
     enabled: false
+  volumes:
+    - name: cert
+      secret:
+        defaultMode: 420
+        secretName: capi-operator-webhook-service-cert
+    - name: clusterctl-config
+      configMap:
+        name: clusterctl-config
+  volumeMounts:
+    manager:
+      - mountPath: /tmp/k8s-webhook-server/serving-certs
+        name: cert
+        readOnly: true
+      - mountPath: /config
+        name: clusterctl-config
+        readOnly: true
   cluster-api:
     enabled: true
     version: v1.4.6

--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -32,7 +32,6 @@ variables:
   RANCHER_PATH: "rancher-latest/rancher"
   CPI_IMAGE_K8S_VERSION: "v1.27.0"
   RKE2_VERSION: "v1.26.8+rke2r1"
-  CAPI_CORE: "cluster-api:v1.4.6"
   RANCHER_REPO_NAME: "rancher-latest"
   RANCHER_URL: "https://releases.rancher.com/server-charts/latest"
   CERT_MANAGER_URL: "https://charts.jetstack.io"

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -99,7 +99,6 @@ const (
 	CertManagerRepoNameVar = "CERT_MANAGER_REPO_NAME"
 	CertManagerPathVar     = "CERT_MANAGER_PATH"
 	CapiInfrastructureVar  = "CAPI_INFRASTRUCTURE"
-	CapiCoreVar            = "CAPI_CORE"
 
 	NgrokRepoNameVar  = "NGROK_REPO_NAME"
 	NgrokUrlVar       = "NGROK_URL"

--- a/test/e2e/data/capi-operator/capi-providers.yaml
+++ b/test/e2e/data/capi-operator/capi-providers.yaml
@@ -12,6 +12,5 @@ metadata:
 spec:
   name: docker
   type: infrastructure
-  version: v1.4.6
   configSecret:
     name: variables


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Helm chart installs a config map with a list of provider versions to use. This is mounted in a known location for the CAPI Operator deployment, allowing for the clusterctl to pick these values as default provided. 

If no version is explicitly specified while creating a provider, then the version deployed will always be consistent with the version in the ConfigMap.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #401 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
