### PR TITLE
:seedling: chore: configure janitor to cleanup aws resources

### DIFF
--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  janitor:
+  azure-janitor:
     name: azure-janitor
     runs-on: ubuntu-latest
     steps:
@@ -19,3 +19,17 @@ jobs:
             client-secret: ${{ secrets.AZURE_CLIENT_SECRET}}
             tenant-id: ${{ secrets.AZURE_TENANT_ID}}
             commit: true
+  aws-janitor:
+    if: success() || failure()
+    name: aws-janitor
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Cleanup
+        uses: rancher-sandbox/aws-janitor@v0.1.0
+        with:
+          regions: eu-west-2
+          commit: true
+          ignore-tag: janitor-ignore


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable `aws-janitor` to clean resources using a mark and delete approach (first execution mark/next delete), including:
- EKS clusters.
- Auto Scaling Groups.
- Load Balancers.
- Security Groups.
- CloudFormation stacks.

**Resources that include the tag `janitor-ignore` will be skipped.**

**Which issue(s) this PR fixes**:
Fixes #368 

**Special notes for your reviewer**:

This PR is waiting on an initial release of https://github.com/rancher-sandbox/aws-janitor, which will be created after https://github.com/rancher-sandbox/aws-janitor/pull/4.

`aws-janitor` runs after `azure-janitor`. It will run even if the previous job fails and it'll be skipped only if the action is cancelled.

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
