### PR TITLE
🌱 chore: update go version in release test workflow

### DIFF
--- a/.github/workflows/nightly-test-release.yaml
+++ b/.github/workflows/nightly-test-release.yaml
@@ -104,6 +104,10 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+      - name: setupGo
+        uses: actions/setup-go@v5
+        with:
+          go-version: '=1.22.0'
       - name: Package operator chart
         run: RELEASE_TAG=${{ env.RELEASE_TAG }} CHART_PACKAGE_DIR=${RELEASE_DIR} REGISTRY=${{ env.PROD_REGISTRY }} ORG=${{ env.PROD_ORG }} make release
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,6 +96,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: setupGo
+        uses: actions/setup-go@v5
+        with:
+          go-version: '=1.22.0'
       - name: Get prod multiarch image digest
         run: | 
           docker pull ${{ env.CONTROLLER_IMG }}:${{ env.TAG }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Release workflow is failing after the move to Go 1.22. This PR explicitly configures the action to run the new Go version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
