### PR TITLE
:seedling: test: add wait-delete-cluster interval

### DIFF
--- a/test/e2e/config/operator.yaml
+++ b/test/e2e/config/operator.yaml
@@ -8,6 +8,7 @@ images:
 intervals:
   default/wait-controllers: ["15m", "10s"]
   default/wait-rancher: ["15m", "30s"]
+  default/wait-delete-cluster: ["15m", "30s"]
   default/wait-v2prov-create: ["25m", "30s"]
   default/wait-capa-create-cluster: ["30m", "30s"]
   default/wait-capz-create-cluster: ["35m", "30s"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Looks like the interval `wait-delete-cluster` used when cleaning up the E2E test environment is missing. If it takes longer to remove the cluster, this causes it to time out.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
