### PR TITLE
:bug: Provider re apply tests

### DIFF
--- a/internal/controllers/capiprovider_controller_test.go
+++ b/internal/controllers/capiprovider_controller_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -147,7 +145,7 @@ var _ = Describe("Reconcile CAPIProvider", func() {
 			}
 		})).Should(Succeed())
 
-		Eventually(Object(doSecret), 10*time.Second).Should(HaveField("Data", Equal(map[string][]byte{
+		Eventually(Object(doSecret)).Should(HaveField("Data", Equal(map[string][]byte{
 			"EXP_MACHINE_POOL":          []byte("true"),
 			"CLUSTER_TOPOLOGY":          []byte("false"),
 			"EXP_CLUSTER_RESOURCE_SET":  []byte("false"),

--- a/internal/sync/secret_mapper_sync_test.go
+++ b/internal/sync/secret_mapper_sync_test.go
@@ -186,10 +186,11 @@ var _ = Describe("SecretMapperSync get", func() {
 			RancherSecret: sync.SecretMapperSync{}.GetSecret(capiProviderWithRancherRef),
 		}
 
-		err := syncer.Get(context.Background())
-		Expect(err).NotTo(HaveOccurred())
-		Expect(syncer.RancherSecret.Name).To(Equal(customRancherSecret.Name))
-		Expect(syncer.RancherSecret.Namespace).To(Equal(customRancherSecret.Namespace))
+		Eventually(func(g Gomega) {
+			g.Expect(syncer.Get(context.Background())).NotTo(HaveOccurred())
+			g.Expect(syncer.RancherSecret.Name).To(Equal(customRancherSecret.Name))
+			g.Expect(syncer.RancherSecret.Namespace).To(Equal(customRancherSecret.Namespace))
+		})
 	})
 
 	It("should handle unexisting secret pointer by ref", func() {
@@ -204,12 +205,13 @@ var _ = Describe("SecretMapperSync get", func() {
 			RancherSecret: sync.SecretMapperSync{}.GetSecret(capiProviderWithRancherRef),
 		}
 
-		err := syncer.Get(context.Background())
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("unable to locate rancher secret with name"))
-		Expect(conditions.Get(syncer.Source, turtlesv1.RancherCredentialsSecretCondition)).ToNot(BeNil())
-		Expect(conditions.IsFalse(syncer.Source, turtlesv1.RancherCredentialsSecretCondition)).To(BeTrue())
-		Expect(conditions.GetMessage(syncer.Source, turtlesv1.RancherCredentialsSecretCondition)).To(Equal(fmt.Sprintf("Rancher Credentials secret named %s:secret-name was not located", ns.Name)))
+		Eventually(func(g Gomega) {
+			g.Expect(syncer.Get(context.Background())).NotTo(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring("unable to locate rancher secret with name"))
+			g.Expect(conditions.Get(syncer.Source, turtlesv1.RancherCredentialsSecretCondition)).ToNot(BeNil())
+			g.Expect(conditions.IsFalse(syncer.Source, turtlesv1.RancherCredentialsSecretCondition)).To(BeTrue())
+			g.Expect(conditions.GetMessage(syncer.Source, turtlesv1.RancherCredentialsSecretCondition)).To(Equal(fmt.Sprintf("Rancher Credentials secret named %s:secret-name was not located", ns.Name)))
+		})
 	})
 
 	It("should handle when the source Rancher secret is not found", func() {

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&profilerAddress, "profiler-address", "",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
 
-	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
+	fs.DurationVar(&syncPeriod, "sync-period", 2*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Add logic for conditions merge on CAPIProvider resource. This fixes situation when a LastAppliedConfigurationTime is set, but is overwritten by the child CAPI Operator conditions, causing forced cleanup of annotation and infinite reconciles.

Additionally, cache re-sync time reduced to 2 minutes so that the infrastructure is re-applied periodically.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #407 
Depends on #396 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
